### PR TITLE
chore: fix workspace directories

### DIFF
--- a/blurple-canvas-web.code-workspace
+++ b/blurple-canvas-web.code-workspace
@@ -5,13 +5,13 @@
       "path": "."
     },
     {
-      "path": "backend"
+      "path": "packages/backend"
     },
     {
-      "path": "frontend"
+      "path": "packages/frontend"
     },
     {
-      "path": "types"
+      "path": "packages/types"
     }
   ],
   "settings": {


### PR DESCRIPTION
Packages should be in `/packages`, not in root