### PR TITLE
chore: format Prisma files

### DIFF
--- a/blurple-canvas-web.code-workspace
+++ b/blurple-canvas-web.code-workspace
@@ -65,6 +65,9 @@
     },
     "[markdown]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[prisma]": {
+      "editor.defaultFormatter": "Prisma.prisma"
     }
   },
   "extensions": {
@@ -74,6 +77,7 @@
       "EditorConfig.EditorConfig",
       "esbenp.prettier-vscode",
       "humao.rest-client",
+      "Prisma.prisma",
       "streetsidesoftware.code-spell-checker"
     ]
   }


### PR DESCRIPTION
@pumbas600 mentioned in https://github.com/UOA-CS732-SE750-Students-2024/project-group-golden-giraffes/pull/29#issuecomment-2028593984 that he’s manually formatting Prisma files, which shan’t do