### PR TITLE
docs: stub `examples.rest` file

### DIFF
--- a/packages/backend/examples.rest
+++ b/packages/backend/examples.rest
@@ -1,4 +1,4 @@
-@basePath = http://localhost:8000
+@basePath = http://localhost:{{$dotenv PORT}}
 # Amend and uncomment next line to use a remote deployment
 # @basePath = https://example.projectblurple.com/api/v1
 


### PR DESCRIPTION
This is the thing that the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension uses. We basically just write out in plaintext example calls to our API, and then you can just click <kbd>Send request</kbd> above the request header and it’ll do just that. (It’ll also look for fenced code blocks in Markdown files marked `http` or `rest`)

The purposes of this is not only for manual testing (please still write unit tests!), but it’s also an excellent way to show how to, y’know, use the endpoint. It documents the I in API

This file can also be called `examples.http`. I don’t have too strong a preference, but this has a bit more overlap with the extension name