### PR TITLE
chore: configure what languages cSpell is enabled for

### DIFF
--- a/blurple-canvas-web.code-workspace
+++ b/blurple-canvas-web.code-workspace
@@ -23,11 +23,12 @@
       "javascriptreact",
       "markdown",
       "plaintext",
+      "shellscript",
+      "sql",
       "text",
       "typescript",
       "typescriptreact",
-      "yaml",
-      "yml"
+      "yaml"
     ],
     "cSpell.language": "en-GB",
     "cSpell.overrides": [


### PR DESCRIPTION
**What's Changed?**

cSpell doesn't support disabling specific languages, so I just removed it from the languages it's enabled for. I also removed some of the languages that don't make any sense for this project (E.g. C#, C, C++, Vue, etc)