### PR TITLE
feat: add invisible image for loading canvas earlier

### DIFF
--- a/packages/backend/src/routes/api/v1/canvas.ts
+++ b/packages/backend/src/routes/api/v1/canvas.ts
@@ -61,6 +61,7 @@ function sendCachedCanvas(
       res
         .status(200)
         .type("png")
+        .setHeader("Cache-Control", "no-cache no-store")
         .setHeader("Content-Disposition", `inline; filename="${filename}"`),
     );
 }

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -100,7 +100,9 @@ export default function CanvasView({ imageUrl, children }: CanvasViewProps) {
   }, []);
 
   useEffect(() => {
-    // It seems sometimes the image onLoad doesn't fire.
+    // The image onLoad doesn't always seem to fire, especially on reloads. Instead, the image
+    // seems pre-loaded. This may have something to do with SSR, or browser image caching. We'll
+    // need to check it's working correctly when we start placing pixels.
     if (imageRef.current?.complete) {
       handleLoadImage(imageRef.current);
     }


### PR DESCRIPTION
**What's Changed?**
- Added an invisible image which causes the image to start getting loaded significantly earlier.
- Added `Cache-Control` header to definitely make sure unlocked images aren't being cached by browsers.