### PR TITLE
feat: return location of selected pixel

### DIFF
--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -333,10 +333,10 @@ export default function CanvasView({ imageUrl }: CanvasViewProps) {
   );
 
   useEffect(() => {
-    canvasRef.current?.addEventListener("mousedown", handleCanvasClick);
+    canvasRef.current?.addEventListener("click", handleCanvasClick);
 
     return () =>
-      canvasRef.current?.removeEventListener("mousedown", handleCanvasClick);
+      canvasRef.current?.removeEventListener("click", handleCanvasClick);
   }, [handleCanvasClick]);
 
   return (


### PR DESCRIPTION
CORS is a bit silly, so I've set the cross-origin to be anonymous. Currently not worth our time to set up CORS headers or proxies or whatever.

### Achieved

- Returns a console log of the pixel position.
- Triggers on every single mouse click event.

### Next Steps

- Make sure that we ignore the output if the mouse has been dragged at all (check global positions).
- Show overlay on the pixel clicked.