### PR TITLE
feat: attached guild name cache

### DIFF
--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -74,6 +74,12 @@ model discord_user_profile {
   history             history[]
 }
 
+model discord_guild_record {
+  guild_id BigInt  @id
+  name     String
+  guild    guild[]
+}
+
 model event {
   id           Int             @id
   name         String
@@ -97,13 +103,14 @@ model frame {
 }
 
 model guild {
-  id              BigInt              @id
-  manager_role    BigInt?
-  invite          String?
-  history         history[]
-  participantions participation[]
-  guild_stats     guild_stats[]
-  leaderboard     leaderboard_guild[]
+  id                   BigInt                @id
+  discord_guild_record discord_guild_record? @relation(fields: [id], references: [guild_id])
+  manager_role         BigInt?
+  invite               String?
+  history              history[]
+  participantions      participation[]
+  guild_stats          guild_stats[]
+  leaderboard          leaderboard_guild[]
 }
 
 model history {

--- a/packages/backend/src/services/paletteService.ts
+++ b/packages/backend/src/services/paletteService.ts
@@ -34,7 +34,7 @@ export async function getEventPalette(
       rgba: true,
       participations: {
         select: {
-          guild: { select: { invite: true } }, // Include the guild invite
+          guild: { select: { invite: true, discord_guild_record: true } }, // Include the guild invite
         },
         // Only include the participation for the event we're looking at. This way the only element
         // in the participations array will be the one for the event we're looking at.
@@ -63,5 +63,7 @@ export async function getEventPalette(
     // We don't need to worry about the size of participations because JS doesn't throw index out
     // of bounds errors, instead it just returns undefined.
     invite: color.participations[0]?.guild?.invite ?? null,
+    guildName:
+      color.participations[0]?.guild?.discord_guild_record?.name ?? null,
   }));
 }

--- a/packages/types/src/discordGuildRecord.d.ts
+++ b/packages/types/src/discordGuildRecord.d.ts
@@ -1,0 +1,4 @@
+export interface DiscordGuildRecord {
+  guild_id: string;
+  name: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./api";
 export * from "./canvasInfo";
+export * from "./discordGuildRecord";
 export * from "./discordUserProfile";
 export * from "./pixelInfo";
 export * from "./event";

--- a/packages/types/src/palette.d.ts
+++ b/packages/types/src/palette.d.ts
@@ -5,6 +5,7 @@ export interface PaletteColor {
   rgba: number[]; // [r, g, b, a]
   global: boolean;
   invite: string | null;
+  guildName: string | null;
 }
 
 export type Palette = PaletteColor[];


### PR DESCRIPTION
- Connects to already-populated `discord_guild_record` db table
- Can now fetch guild name when fetching palette