### PR TITLE
fix: logging out causing errors

### DIFF
--- a/packages/frontend/src/app/me/MePageContent.tsx
+++ b/packages/frontend/src/app/me/MePageContent.tsx
@@ -41,8 +41,14 @@ const StatsCard = styled("div")`
 `;
 
 export default function MePageContent() {
+  const { canvas: activeCanvas } = useActiveCanvasContext();
   const { signOut, user } = useAuthContext();
   const router = useRouter();
+
+  const { data: stats, isLoading: statsAreLoading } = useUserStats(
+    user?.id,
+    activeCanvas.id,
+  );
 
   useEffect(() => {
     if (!user) {
@@ -50,16 +56,9 @@ export default function MePageContent() {
     }
   }, [user, router]);
 
-  if (!user) return null;
+  if (!user || !activeCanvas) return null;
 
   const { username, profilePictureUrl } = user;
-  const { canvas: activeCanvas } = useActiveCanvasContext();
-
-  if (!activeCanvas) return null;
-  const { data: stats, isLoading: statsAreLoading } = useUserStats(
-    user.id,
-    activeCanvas.id,
-  );
 
   return (
     <Container>
@@ -76,7 +75,10 @@ export default function MePageContent() {
       </SignOutButton>
       <StatsCard>
         <h2>{activeCanvas.name}</h2>
-        <StatsTable stats={stats} statsAreLoading={statsAreLoading} />
+        <StatsTable
+          stats={stats ?? undefined}
+          statsAreLoading={statsAreLoading}
+        />
       </StatsCard>
     </Container>
   );

--- a/packages/frontend/src/hooks/queries/useUserStats.tsx
+++ b/packages/frontend/src/hooks/queries/useUserStats.tsx
@@ -7,15 +7,16 @@ import config from "@/config";
 import {
   CanvasInfo,
   DiscordUserProfile,
-  EventRequest,
   UserStatsRequest,
 } from "@blurple-canvas-web/types";
 
 export function useUserStats(
-  userId: DiscordUserProfile["id"],
+  userId: DiscordUserProfile["id"] | undefined,
   canvasId: CanvasInfo["id"],
 ) {
   const getUserStats = async () => {
+    if (!userId) return null;
+
     const response = await axios.get<UserStatsRequest.ResBody>(
       `${config.apiUrl}/api/v1/statistics/user/${userId}/${canvasId}`,
     );


### PR DESCRIPTION
Previously signing out caused some hooks to not be called. Conditionally calling hooks causes errors.