### PR TITLE
feat(frontend): zooming and panning improvements

### DIFF
--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -320,6 +320,7 @@ export default function CanvasView() {
         return clampOffset(addPoints(scaledOffsetDiff, prevOffset));
       });
 
+      // Use css transition for zoom due to macOS trackpads having high polling rates resulting in laggy zooming if implemented differently
       setTransitionDuration(ZOOM_DURATION);
       setZoom(newZoom);
     };
@@ -423,6 +424,7 @@ export default function CanvasView() {
     [handlePan, handlePointerUp, changeGlobalSelectStyle],
   );
 
+  // Could potentially get replaced by a transition animation with ease, however this will work on Safari
   useEffect(() => {
     const decayVelocity = () => {
       if (velocity.x < 0.1 && velocity.y < 0.1) return;

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -300,12 +300,15 @@ export default function CanvasView() {
         mousePositionOnCanvas,
       );
 
+      if (event.deltaY === 0) return;
       // Inclusion of deltaY in calculation to account for different polling rate devices
-      const scale = zoom * (1 + SCALE_FACTOR * -event.deltaY);
-      const newZoom = clamp(scale, MIN_ZOOM * initialZoom, MAX_ZOOM);
+      // Could try logarithmic scale for smoother increments
+      const scale = 1 + SCALE_FACTOR * Math.max(Math.abs(event.deltaY), 1);
+      const newZoom = event.deltaY > 0 ? zoom / scale : zoom * scale;
+      const clampedZoom = clamp(newZoom, MIN_ZOOM * initialZoom, MAX_ZOOM);
 
       // Clamping the zoom means the actual scale may be different.
-      const clampedScale = newZoom / zoom;
+      const clampedScale = clampedZoom / zoom;
 
       setOffset((prevOffset) => {
         // Calculate the of the mouse position relative to the center of the canvas in the container
@@ -320,7 +323,7 @@ export default function CanvasView() {
 
       // Use css transition for zoom due to macOS trackpads having high polling rates resulting in laggy zooming if implemented differently
       setTransitionDuration(ZOOM_DURATION);
-      setZoom(newZoom);
+      setZoom(clampedZoom);
     };
 
     containerRef.current?.addEventListener("wheel", handleWheel, {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -135,6 +135,13 @@ const MAX_ZOOM = 100;
 const MIN_ZOOM = 0.5;
 
 const ZOOM_DURATION = 0.1;
+// Transition animation on canvas pan and zoom is blurred on Safari and needs to be disabled.
+// If the user spoof their user agent, this is not my problem.
+// Bug in question https://bugs.webkit.org/show_bug.cgi?id=27684
+const IS_SAFARI =
+  navigator.userAgent.includes("Safari/") &&
+  !navigator.userAgent.includes("Chrome/") &&
+  !navigator.userAgent.includes("Chromium/");
 
 // This is to avoid weird business with the reticle not sizing properly
 const RETICLE_ORIGINAL_SCALE = 10;
@@ -543,7 +550,8 @@ export default function CanvasView() {
           ref={canvasPanAndZoomRef}
           style={{
             transform: `matrix(${zoom}, 0, 0, ${zoom}, ${offset.x * zoom}, ${offset.y * zoom})`,
-            transition: `transform ${transitionDuration}s ease-out`,
+            transition:
+              IS_SAFARI ? "" : `transform ${transitionDuration}s ease-out`,
           }}
         >
           <ReticleContainer

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -381,7 +381,7 @@ export default function CanvasView() {
   );
 
   /* A bit heavy handed, but it prevents elements outside of the canvas from being selected during panning */
-  const changeGlobalSelectStyle = useCallback((style: "none" | "auto") => {
+  const changeGlobalSelectStyle = useCallback((style: "none" | "initial") => {
     document.body.style.userSelect = style;
     // only -webkit-user-select style exists on Safari: https://caniuse.com/mdn-css_properties_user-select
     document.body.style.webkitUserSelect = style;
@@ -396,7 +396,7 @@ export default function CanvasView() {
       if (!(elem instanceof HTMLElement)) return;
       elem.releasePointerCapture(event.pointerId);
 
-      changeGlobalSelectStyle("auto");
+      changeGlobalSelectStyle("initial");
       setControlledPan(false);
 
       elem.removeEventListener("pointermove", handlePan);

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -365,7 +365,7 @@ export default function CanvasView() {
     [zoom, clampOffset],
   );
 
-  const handleMouseMove = useCallback(
+  const handlePan = useCallback(
     (event: PointerEvent): void => {
       // Disable transitions while panning
       setTransitionDuration(0);
@@ -380,29 +380,29 @@ export default function CanvasView() {
   /**
    * Remove the listeners when the mouse is released to stop panning.
    */
-  const handleMouseUp = useCallback((): void => {
+  const handlePointerUp = useCallback((): void => {
     if (!containerRef.current) return;
 
     setControlledPan(false);
 
-    containerRef.current.removeEventListener("pointermove", handleMouseMove);
-    containerRef.current.removeEventListener("pointerup", handleMouseUp);
-    containerRef.current.removeEventListener("pointerleave", handleMouseUp);
-  }, [handleMouseMove]);
+    containerRef.current.removeEventListener("pointermove", handlePan);
+    containerRef.current.removeEventListener("pointerup", handlePointerUp);
+    containerRef.current.removeEventListener("pointerleave", handlePointerUp);
+  }, [handlePan]);
 
   /**
    * Only add the mouse move listener when you click down so that moving your mouse normally doesn't
    * cause the canvas to pan.
    */
-  const handleStartMousePan = useCallback((): void => {
+  const handlePointerDown = useCallback((): void => {
     if (!containerRef.current) return;
 
     setControlledPan(true);
 
-    containerRef.current.addEventListener("pointermove", handleMouseMove);
-    containerRef.current.addEventListener("pointerup", handleMouseUp);
-    containerRef.current.addEventListener("pointerleave", handleMouseUp);
-  }, [handleMouseMove, handleMouseUp]);
+    containerRef.current.addEventListener("pointermove", handlePan);
+    containerRef.current.addEventListener("pointerup", handlePointerUp);
+    containerRef.current.addEventListener("pointerleave", handlePointerUp);
+  }, [handlePan, handlePointerUp]);
 
   useEffect(() => {
     const decayVelocity = () => {
@@ -472,7 +472,7 @@ export default function CanvasView() {
 
   return (
     <>
-      <CanvasContainer ref={containerRef} onPointerDown={handleStartMousePan}>
+      <CanvasContainer ref={containerRef} onPointerDown={handlePointerDown}>
         {config.discordServerInvite && (
           <a href={config.discordServerInvite} target="_blank" rel="noreferrer">
             <InviteButton>Project Blurple</InviteButton>

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -125,7 +125,7 @@ function getDefaultZoom(
   return scale;
 }
 
-const SCALE_FACTOR = 0.2;
+const SCALE_FACTOR = 0.002;
 const MAX_ZOOM = 100;
 const MIN_ZOOM = 0.5;
 
@@ -298,8 +298,9 @@ export default function CanvasView() {
         mousePositionOnCanvas,
       );
 
-      const scale = Math.exp(Math.sign(-event.deltaY) * SCALE_FACTOR);
-      const newZoom = clamp(zoom * scale, MIN_ZOOM, MAX_ZOOM);
+      // Inclusion of deltaY in calculation to account for different polling rate devices
+      const scale = zoom * (1 + SCALE_FACTOR * -event.deltaY);
+      const newZoom = clamp(scale, MIN_ZOOM, MAX_ZOOM);
 
       // Clamping the zoom means the actual scale may be different.
       const clampedScale = newZoom / zoom;

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -499,7 +499,9 @@ export default function CanvasView() {
           style={{
             transform: `matrix(${zoom}, 0, 0, ${zoom}, ${offset.x}, ${offset.y})`,
             transition:
-              IS_SAFARI ? "" : `transform ${transitionDuration}s ease-out`,
+              IS_SAFARI ? undefined : (
+                `transform ${transitionDuration}s ease-out`
+              ),
           }}
         >
           <ReticleContainer

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -380,29 +380,34 @@ export default function CanvasView() {
   /**
    * Remove the listeners when the mouse is released to stop panning.
    */
-  const handlePointerUp = useCallback((): void => {
-    if (!containerRef.current) return;
+  const handlePointerUp = useCallback(
+    (event: PointerEvent): void => {
+      const elem = event.currentTarget;
+      if (!(elem instanceof HTMLElement)) return;
+      setControlledPan(false);
 
-    setControlledPan(false);
-
-    containerRef.current.removeEventListener("pointermove", handlePan);
-    containerRef.current.removeEventListener("pointerup", handlePointerUp);
-    containerRef.current.removeEventListener("pointerleave", handlePointerUp);
-  }, [handlePan]);
+      elem.removeEventListener("pointermove", handlePan);
+      elem.removeEventListener("pointerup", handlePointerUp);
+      elem.removeEventListener("pointerleave", handlePointerUp);
+    },
+    [handlePan],
+  );
 
   /**
    * Only add the mouse move listener when you click down so that moving your mouse normally doesn't
    * cause the canvas to pan.
    */
-  const handlePointerDown = useCallback((): void => {
-    if (!containerRef.current) return;
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const elem = event.currentTarget;
+      setControlledPan(true);
 
-    setControlledPan(true);
-
-    containerRef.current.addEventListener("pointermove", handlePan);
-    containerRef.current.addEventListener("pointerup", handlePointerUp);
-    containerRef.current.addEventListener("pointerleave", handlePointerUp);
-  }, [handlePan, handlePointerUp]);
+      elem.addEventListener("pointermove", handlePan);
+      elem.addEventListener("pointerup", handlePointerUp);
+      elem.addEventListener("pointerleave", handlePointerUp);
+    },
+    [handlePan, handlePointerUp],
+  );
 
   useEffect(() => {
     const decayVelocity = () => {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -159,7 +159,6 @@ export default function CanvasView() {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasImageWrapperRef = useRef<HTMLImageElement>(null);
   const canvasPanAndZoomRef = useRef<HTMLDivElement>(null);
-  // const startTouchesRef = useRef<Touch[]>([]);
 
   const { color } = useSelectedColorContext();
   const { canvas, coords, setCoords } = useCanvasContext();

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -36,7 +36,7 @@ const CanvasContainer = styled("div")`
   place-content: center;
   place-items: center;
   /* Fixes blurry canvas in Safari when canvasImage overlaps with overflow, don't ask why */
-  -webkit-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
 
   :active {
     cursor: grabbing;

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -33,6 +33,12 @@ const CanvasContainer = styled("div")`
   /* Don't handle panning and zooming with browser */
   touch-action: none;
 
+  /* A bit heavy handed, but it prevents elements outside of the canvas from being selected during panning */
+  body:has(&:active) {
+    --webkit-user-select: none;
+    user-select: none;
+  }
+
   :active {
     cursor: grabbing;
   }
@@ -380,13 +386,6 @@ export default function CanvasView() {
     [updateOffset, zoom],
   );
 
-  /* A bit heavy handed, but it prevents elements outside of the canvas from being selected during panning */
-  const changeGlobalSelectStyle = useCallback((style: "none" | "initial") => {
-    document.body.style.userSelect = style;
-    // only -webkit-user-select style exists on Safari: https://caniuse.com/mdn-css_properties_user-select
-    document.body.style.webkitUserSelect = style;
-  }, []);
-
   /**
    * Remove the listeners when the mouse is released to stop panning.
    */
@@ -396,14 +395,13 @@ export default function CanvasView() {
       if (!(elem instanceof HTMLElement)) return;
       elem.releasePointerCapture(event.pointerId);
 
-      changeGlobalSelectStyle("initial");
       setControlledPan(false);
 
       elem.removeEventListener("pointermove", handlePan);
       elem.removeEventListener("pointerup", handlePointerUp);
       elem.removeEventListener("pointercancel", handlePointerUp);
     },
-    [handlePan, changeGlobalSelectStyle],
+    [handlePan],
   );
 
   /**
@@ -414,15 +412,13 @@ export default function CanvasView() {
     (event: React.PointerEvent<HTMLDivElement>) => {
       const elem = event.currentTarget;
       elem.setPointerCapture(event.pointerId);
-
-      changeGlobalSelectStyle("none");
       setControlledPan(true);
 
       elem.addEventListener("pointermove", handlePan);
       elem.addEventListener("pointerup", handlePointerUp);
       elem.addEventListener("pointercancel", handlePointerUp);
     },
-    [handlePan, handlePointerUp, changeGlobalSelectStyle],
+    [handlePan, handlePointerUp],
   );
 
   // Could potentially get replaced by a transition animation with ease, however this will work on Safari

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -127,7 +127,7 @@ function getDefaultZoom(
 
 const SCALE_FACTOR = 0.002;
 const MAX_ZOOM = 100;
-const MIN_ZOOM = 0.5;
+const MIN_ZOOM = 0.9;
 
 const ZOOM_DURATION = 0.1;
 const PAN_DECAY = 0.75;
@@ -170,16 +170,18 @@ export default function CanvasView() {
   );
   const [isLoading, setIsLoading] = useState(false);
   const [zoom, setZoom] = useState(1);
+  const [initialZoom, setInitialZoom] = useState(1);
   const [offset, setOffset] = useState(ORIGIN);
   const [velocity, setVelocity] = useState<Point>({ x: 0, y: 0 });
   const [controlledPan, setControlledPan] = useState(false);
   const [transitionDuration, setTransitionDuration] = useState(0);
 
   const handleLoadImage = useCallback((image: HTMLImageElement): void => {
-    const initialZoom =
+    const zoom =
       containerRef.current ? getDefaultZoom(containerRef.current, image) : 1;
 
-    setZoom(initialZoom);
+    setInitialZoom(zoom);
+    setZoom(zoom);
     setVelocity(ORIGIN);
     setOffset(ORIGIN);
     setIsLoading(false);
@@ -300,7 +302,7 @@ export default function CanvasView() {
 
       // Inclusion of deltaY in calculation to account for different polling rate devices
       const scale = zoom * (1 + SCALE_FACTOR * -event.deltaY);
-      const newZoom = clamp(scale, MIN_ZOOM, MAX_ZOOM);
+      const newZoom = clamp(scale, MIN_ZOOM * initialZoom, MAX_ZOOM);
 
       // Clamping the zoom means the actual scale may be different.
       const clampedScale = newZoom / zoom;
@@ -327,7 +329,7 @@ export default function CanvasView() {
 
     return () =>
       containerRef.current?.removeEventListener("wheel", handleWheel);
-  }, [zoom, getRelativeMousePosition]);
+  }, [initialZoom, zoom, getRelativeMousePosition]);
 
   /********************************
    * PANNING FUNCTIONALITY.       *

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -287,11 +287,10 @@ export default function CanvasView() {
       // Ideally, the scrolling should work outside of canvas-image-wrapper, but I can't seem to get the behaviour correct.
       const elem = event.target;
       if (!(elem instanceof HTMLElement)) return;
-      if (elem.id !== "canvas-image-wrapper") return;
 
-      // The mouse position's origin is in the top left of the canvas. The offset's origin is the
-      // center of the canvas so we do this to convert between the two.
-      const mouseOffsetDirection = diffPoints(
+      // The mouse position's origin is in the top left of the container.
+      // Converts this to the offset from the center of the visual container
+      const mouseOffset = diffPoints(
         { x: elem.offsetWidth / 2, y: elem.offsetHeight / 2 },
         mousePositionOnCanvas,
       );
@@ -303,12 +302,13 @@ export default function CanvasView() {
       const effectiveScale = newZoom / zoom;
 
       setOffset((prevOffset) => {
-        // The direction we need to shift the offset to keep the pixel in the same place
-        const offsetDif = diffPoints(mouseOffsetDirection, prevOffset);
+        // Calculate the of the mouse position relative to the center of the canvas in the container
+        const trueOffset = diffPoints(mouseOffset, prevOffset);
+        console.log(mousePositionOnCanvas, mouseOffset, prevOffset, trueOffset);
 
         // The amount we shift is scaled based on the amount we've zoomed in.
         const scaledOffsetDiff = multiplyPoint(
-          offsetDif,
+          trueOffset,
           // If the scale is 1, we've not zoomed in at all and so this multiplier becomes 0
           // (causing no offset). If the scale is greater than 1, we're zooming in. A larger scale
           // corresponds to a larger step (as 1/effectiveScale approaches 0). If the scale is less
@@ -322,7 +322,7 @@ export default function CanvasView() {
 
       // Use css transition for zoom due to macOS trackpads having high polling rates resulting in laggy zooming if implemented differently
       setTransitionDuration(ZOOM_DURATION);
-      setZoom(newZoom);
+      // setZoom(newZoom);
     };
 
     containerRef.current?.addEventListener("wheel", handleWheel, {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -331,7 +331,7 @@ export default function CanvasView() {
 
     return () =>
       containerRef.current?.removeEventListener("wheel", handleWheel);
-  }, [initialZoom, zoom, getRelativeMousePosition]);
+  }, [initialZoom, zoom]);
 
   /********************************
    * PANNING FUNCTIONALITY.       *
@@ -467,7 +467,7 @@ export default function CanvasView() {
       // we only care about updating the location
       setCoords(boundedCanvasPos);
     },
-    [zoom, setCoords, getRelativeMousePosition],
+    [zoom, setCoords],
   );
 
   useEffect(() => {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -125,6 +125,14 @@ function getDefaultZoom(
   return scale;
 }
 
+/**
+ * Calculate the position of the mouse relative to the given element
+ **/
+function getRelativeMousePosition(element: HTMLElement, event: MouseEvent) {
+  const rect = element.getBoundingClientRect();
+  return { x: event.clientX - rect.left, y: event.clientY - rect.top };
+}
+
 const SCALE_FACTOR = 0.002;
 const MAX_ZOOM = 100;
 const MIN_ZOOM = 0.9;
@@ -268,14 +276,6 @@ export default function CanvasView() {
   /********************************
    * ZOOMING FUNCTIONALITY.       *
    ********************************/
-
-  const getRelativeMousePosition = useCallback(
-    (element: HTMLElement, event: MouseEvent) => {
-      const rect = element.getBoundingClientRect();
-      return { x: event.clientX - rect.left, y: event.clientY - rect.top };
-    },
-    [],
-  );
 
   useEffect(() => {
     /**

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -424,7 +424,7 @@ export default function CanvasView() {
 
   useEffect(() => {
     const decayVelocity = () => {
-      if (velocity.x === 0 && velocity.y === 0) return;
+      if (velocity.x < 0.1 && velocity.y < 0.1) return;
       if (controlledPan) return;
       updateOffset(velocity);
       const decay = 0.75;

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -130,6 +130,7 @@ const MAX_ZOOM = 100;
 const MIN_ZOOM = 0.5;
 
 const ZOOM_DURATION = 0.1;
+const PAN_DECAY = 0.75;
 // Transition animation on canvas pan and zoom is blurred on Safari and needs to be disabled.
 // If the user spoof their user agent, this is not my problem.
 // Bug in question https://bugs.webkit.org/show_bug.cgi?id=27684
@@ -427,10 +428,9 @@ export default function CanvasView() {
       if (velocity.x < 0.1 && velocity.y < 0.1) return;
       if (controlledPan) return;
       updateOffset(velocity);
-      const decay = 0.75;
       setVelocity((prevVelocity) => ({
-        x: prevVelocity.x * decay,
-        y: prevVelocity.y * decay,
+        x: prevVelocity.x * PAN_DECAY,
+        y: prevVelocity.y * PAN_DECAY,
       }));
     };
 

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -134,6 +134,8 @@ const SCALE_FACTOR = 0.2;
 const MAX_ZOOM = 100;
 const MIN_ZOOM = 0.5;
 
+const ZOOM_DURATION = 0.1;
+
 // This is to avoid weird business with the reticle not sizing properly
 const RETICLE_ORIGINAL_SCALE = 10;
 const RETICLE_ORIGINAL_SIZE = 14;
@@ -168,6 +170,7 @@ export default function CanvasView() {
   const [offset, setOffset] = useState(ORIGIN);
   const [velocity, setVelocity] = useState<Point>({ x: 0, y: 0 });
   const [controlledPan, setControlledPan] = useState(false);
+  const [transitionDuration, setTransitionDuration] = useState(0);
 
   const handleLoadImage = useCallback((image: HTMLImageElement): void => {
     const initialZoom =
@@ -314,6 +317,7 @@ export default function CanvasView() {
         return clampOffset(addPoints(scaledOffsetDiff, prevOffset));
       });
 
+      setTransitionDuration(ZOOM_DURATION);
       setZoom(newZoom);
     };
 
@@ -361,6 +365,9 @@ export default function CanvasView() {
 
   const handleMouseMove = useCallback(
     (event: MouseEvent): void => {
+      // Disable transitions while panning
+      setTransitionDuration(0);
+
       const diff = { x: event.movementX, y: event.movementY };
       setVelocity({ x: diff.x, y: diff.y });
       updateOffset(diff);
@@ -399,6 +406,7 @@ export default function CanvasView() {
     (event: TouchEvent): void => {
       const touchCount = event.touches.length;
       event.preventDefault();
+      setTransitionDuration(0);
 
       // TODO: Implement multi-touch zooming
       if (touchCount !== 1) return;
@@ -535,7 +543,7 @@ export default function CanvasView() {
           ref={canvasPanAndZoomRef}
           style={{
             transform: `matrix(${zoom}, 0, 0, ${zoom}, ${offset.x * zoom}, ${offset.y * zoom})`,
-            transition: "transform 0.1s ease-out",
+            transition: `transform ${transitionDuration}s ease-out`,
           }}
         >
           <ReticleContainer

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -496,9 +496,11 @@ export default function CanvasView() {
    * When the canvas is clicked, we want to know which pixel was clicked on.
    */
   const handleCanvasClick = useCallback(
-    (event: MouseEvent): void => {
-      if (!(event.target instanceof HTMLElement)) return;
-      const canvas = event.target;
+    (event: PointerEvent): void => {
+      if (!(event.currentTarget instanceof HTMLElement) || !event.isPrimary)
+        return;
+      const canvas = event.currentTarget;
+      // Use boundingClientRect for more accurate pixel positioning
       const canvasRect = canvas.getBoundingClientRect();
 
       const mouseX = event.clientX - canvasRect.left;
@@ -520,13 +522,13 @@ export default function CanvasView() {
 
   useEffect(() => {
     canvasImageWrapperRef.current?.addEventListener(
-      "mousedown",
+      "pointerdown",
       handleCanvasClick,
     );
 
     return () =>
       canvasImageWrapperRef.current?.removeEventListener(
-        "mousedown",
+        "pointerdown",
         handleCanvasClick,
       );
   }, [handleCanvasClick]);


### PR DESCRIPTION
~~Would end up removing at lot of the glide zoom code in favour of css animations (and potentially the panning velocity code as well).~~

~~Should be able to:~~

~~- [x] Change zoom~~
~~- [x] Change panning~~
~~- [x] Safari...~~

Changes:

- Zoom animation is done using css transition (transition is disabled on Safari due to bad support) for performance reasons (high polling scroll wheels) and also use deltaY extensively in scrolling logic—should feel more responsive on both trackpad and mouse. 
- Panning is not done using css transition (can't be used on Safari) and doesn't seem to have heavy performance issues.
- Updates touchevent and mouseevent handlers to use the same pointer events.
- Allows scrolling on canvas background.
- Fixes scrolling not being able to differentiate from sub pixels.
- Fixes pan decay event firing recursively until floating point precision prevents it to.

Also seems to be a bug where the boundary clamp is applied too late (later event occurrence).