### PR TITLE
feat(frontend): mobile panning pinch zoom reloaded

### DIFF
--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -137,15 +137,14 @@ function getRelativePointerPosition(element: HTMLElement, event: MouseEvent) {
  * Calculates the various variables required to get pan pinch working
  */
 function calculateTouchOffsetDelta(
-  value1: [PointerEvent, HTMLElement] | undefined,
-  value2: [PointerEvent, HTMLElement] | undefined,
+  event1: PointerEvent | undefined,
+  event2: PointerEvent | undefined,
+  elem: HTMLElement,
 ) {
-  if (value1 === undefined || value2 === undefined)
+  if (event1 === undefined || event2 === undefined)
     return { offset: undefined, scale: undefined, centerOffset: undefined };
-  const [event1, elem1] = value1;
-  const [event2, elem2] = value2;
-  const oldPosition1 = getRelativePointerPosition(elem1, event1);
-  const oldPosition2 = getRelativePointerPosition(elem2, event2);
+  const oldPosition1 = getRelativePointerPosition(elem, event1);
+  const oldPosition2 = getRelativePointerPosition(elem, event2);
   const newPosition1 = addPoints(oldPosition1, {
     x: event1.movementX,
     y: event1.movementY,
@@ -189,7 +188,7 @@ const RETICLE_SIZE = RETICLE_ORIGINAL_SIZE * 10;
 const RETICLE_SCALE = 1 / (RETICLE_ORIGINAL_SCALE * 10);
 const PREVIEW_PIXEL_SIZE = 0.8 * RETICLE_ORIGINAL_SCALE * 10;
 
-const pointerEvents: Map<number, [PointerEvent, HTMLElement]> = new Map();
+const pointerEvents: Map<number, PointerEvent> = new Map();
 // Used to handle pointer events when there are multiple pointers down
 let pointerSyncCounter = 0;
 
@@ -449,10 +448,7 @@ export default function CanvasView() {
 
       if (pointerEvents.size === 2) {
         pointerSyncCounter++;
-        pointerEvents.set(event.pointerId, [
-          event as unknown as PointerEvent,
-          elem,
-        ]);
+        pointerEvents.set(event.pointerId, event as unknown as PointerEvent);
         // Only checks every second pointerEvent to ensure both pointermove events are fired
         if (pointerSyncCounter === 2) {
           const pointerEventValues = pointerEvents.values();
@@ -460,6 +456,7 @@ export default function CanvasView() {
             calculateTouchOffsetDelta(
               pointerEventValues.next().value,
               pointerEventValues.next().value,
+              elem,
             );
           pointerSyncCounter = 0;
           if (!offsetDelta || !scale || !centerOffset) return;
@@ -507,10 +504,7 @@ export default function CanvasView() {
       // Don't store more than 2 pointers for pinch handling
       if (pointerEvents.size < 2) {
         // No idea if this is the right way to define the pointerEvents
-        pointerEvents.set(event.pointerId, [
-          event as unknown as PointerEvent,
-          elem,
-        ]);
+        pointerEvents.set(event.pointerId, event as unknown as PointerEvent);
       }
 
       changeGlobalSelectStyle("none");

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -370,12 +370,10 @@ export default function CanvasView() {
   );
 
   const handlePan = useCallback(
-    (event: PointerEvent): void => {
+    (offsetDelta: { x: number; y: number }): void => {
       // Disable transitions while panning
       setTransitionDuration(0);
-
-      const offset = { x: event.movementX, y: event.movementY };
-      const scaledOffset = multiplyPoint(offset, zoom);
+      const scaledOffset = multiplyPoint(offsetDelta, zoom);
       setVelocity({ x: scaledOffset.x, y: scaledOffset.y });
       updateOffset(scaledOffset);
     },
@@ -388,6 +386,15 @@ export default function CanvasView() {
     // only -webkit-user-select style exists on Safari: https://caniuse.com/mdn-css_properties_user-select
     document.body.style.webkitUserSelect = style;
   }, []);
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent): void => {
+      const elem = event.currentTarget;
+      if (!(elem instanceof HTMLElement)) return;
+      handlePan({ x: event.movementX, y: event.movementY });
+    },
+    [handlePan],
+  );
 
   /**
    * Remove the listeners when the mouse is released to stop panning.
@@ -405,11 +412,11 @@ export default function CanvasView() {
       changeGlobalSelectStyle("initial");
       setControlledPan(false);
 
-      elem.removeEventListener("pointermove", handlePan);
+      elem.removeEventListener("pointermove", handlePointerMove);
       elem.removeEventListener("pointerup", handlePointerUp);
       elem.removeEventListener("pointercancel", handlePointerUp);
     },
-    [handlePan, changeGlobalSelectStyle],
+    [handlePointerMove, changeGlobalSelectStyle],
   );
 
   /**
@@ -429,11 +436,11 @@ export default function CanvasView() {
       changeGlobalSelectStyle("none");
       setControlledPan(true);
 
-      elem.addEventListener("pointermove", handlePan);
+      elem.addEventListener("pointermove", handlePointerMove);
       elem.addEventListener("pointerup", handlePointerUp);
       elem.addEventListener("pointercancel", handlePointerUp);
     },
-    [handlePan, handlePointerUp, changeGlobalSelectStyle],
+    [handlePointerMove, handlePointerUp, changeGlobalSelectStyle],
   );
 
   // Could potentially get replaced by a transition animation with ease, however this will work on Safari

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -14,6 +14,7 @@ import {
   ORIGIN,
   addPoints,
   diffPoints,
+  distanceBetweenPoints,
   dividePoint,
   multiplyPoint,
 } from "./point";
@@ -153,8 +154,8 @@ function calculateTouchOffsetDelta(
     x: event2.movementX,
     y: event2.movementY,
   });
-  const oldMagitude = Math.abs(diffPoints(oldPosition1, oldPosition2).x);
-  const newMagitude = Math.abs(diffPoints(newPosition1, newPosition2).x);
+  const oldMagitude = distanceBetweenPoints(oldPosition1, oldPosition2);
+  const newMagitude = distanceBetweenPoints(newPosition1, newPosition2);
   const relativePosition = dividePoint(
     addPoints(newPosition1, newPosition2),
     2,

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -441,6 +441,9 @@ export default function CanvasView() {
     document.body.style.webkitUserSelect = style;
   }, []);
 
+  /**
+   * Defaults to pan when a single pointer is down, and zoom when two pointers are down.
+   */
   const handlePointerMove = useCallback(
     (event: PointerEvent): void => {
       const elem = event.currentTarget;

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -128,7 +128,7 @@ function getDefaultZoom(
 /**
  * Calculate the position of the mouse relative to the given element
  **/
-function getRelativeMousePosition(element: HTMLElement, event: MouseEvent) {
+function getRelativePointerPosition(element: HTMLElement, event: MouseEvent) {
   const rect = element.getBoundingClientRect();
   return { x: event.clientX - rect.left, y: event.clientY - rect.top };
 }
@@ -305,7 +305,7 @@ export default function CanvasView() {
       // Ideally, the scrolling should work outside of canvas-image-wrapper, but I can't seem to get the behaviour correct.
       const elem = event.currentTarget;
       if (!(elem instanceof HTMLElement)) return;
-      const mousePositionOnCanvas = getRelativeMousePosition(elem, event);
+      const mousePositionOnCanvas = getRelativePointerPosition(elem, event);
 
       // The mouse position's origin is in the top left of the container.
       // Converts this to the offset from the center of the visual container
@@ -506,7 +506,7 @@ export default function CanvasView() {
         return;
       const canvas = event.currentTarget;
       // Use boundingClientRect for more accurate pixel positioning
-      const relativeMousePos = getRelativeMousePosition(canvas, event);
+      const relativeMousePos = getRelativePointerPosition(canvas, event);
       const canvasPos = dividePoint(relativeMousePos, zoom);
 
       const boundedCanvasPos = {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -320,7 +320,8 @@ export default function CanvasView() {
    * @param pointerOffset The offset of the `Point` from the visual center of the wrapping container
    */
   const handleZoom = useCallback(
-    (newZoom: number, pointerOffset: Point) => {
+    (scale: number, pointerOffset: Point) => {
+      const newZoom = scale * zoom;
       const clampedZoom = clamp(newZoom, MIN_ZOOM * initialZoom, MAX_ZOOM);
 
       // Clamping the zoom means the actual scale may be different.
@@ -371,9 +372,10 @@ export default function CanvasView() {
       if (event.deltaY === 0) return;
       // Inclusion of deltaY in calculation to account for different polling rate devices
       // Could try logarithmic scale for smoother increments
-      const scale = 1 + SCALE_FACTOR * Math.max(Math.abs(event.deltaY), 1);
-      const newZoom = event.deltaY > 0 ? zoom / scale : zoom * scale;
-      handleZoom(newZoom, pointerOffset);
+      const scaleMagnitude =
+        1 + SCALE_FACTOR * Math.max(Math.abs(event.deltaY), 1);
+      const scale = event.deltaY > 0 ? 1 / scaleMagnitude : 1 * scaleMagnitude;
+      handleZoom(scale, pointerOffset);
     };
 
     containerRef.current?.addEventListener("wheel", handleWheel, {
@@ -459,14 +461,13 @@ export default function CanvasView() {
           pointerSyncCounter = 0;
           if (!offsetDelta || !scale || !centerOffset) return;
           handlePan(offsetDelta);
-          const newZoom = scale * zoom;
-          handleZoom(newZoom, centerOffset);
+          handleZoom(scale, centerOffset);
         }
       } else {
         handlePan({ x: event.movementX, y: event.movementY });
       }
     },
-    [handlePan, handleZoom, zoom],
+    [handlePan, handleZoom],
   );
 
   /**

--- a/packages/frontend/src/components/canvas/point.ts
+++ b/packages/frontend/src/components/canvas/point.ts
@@ -33,3 +33,7 @@ export function multiplyPoint(p1: Point, scale: number): Point {
 export function tupleToPoint([x, y]: [number, number]): Point {
   return { x, y };
 }
+
+export function distanceBetweenPoints(p1: Point, p2: Point): number {
+  return Math.sqrt((p1.x - p2.x) ** 2 + (p1.y - p2.y)** 2);
+}

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "ES6"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
The long anticipated sequel to the hit PR `feat: mobile panning` comes `feat(frontend): mobile panning pinch zoom reloaded`

In this new instalment, the newly refactored PointerEvent handlers used to panning the Canvas has discovered a new passion, handling multi-touch pinch interactions in mobile. Follow their journey of self discovery, through multiple helper function refactors and mathematical escapades, to ultimately achieve the goal of mobile support.

<details> 
  <summary>Spoiler Alert!!!</summary>
  The sneaky clampOffset and clampZoom bugs escaped unscathed and has staged a revolt. Find out how the story ends in the final part of the trilogy `fix(frontend): mobile panning pinch zoom clamp adjustments revolutions`
</details>