### PR TITLE
feat(frontend): mobile slideable drawer

### DIFF
--- a/packages/frontend/src/app/Main.tsx
+++ b/packages/frontend/src/app/Main.tsx
@@ -4,6 +4,7 @@ import { styled } from "@mui/material";
 
 import { ActionPanel } from "@/components/action-panel";
 import { CanvasView } from "@/components/canvas";
+import { SlideableDrawer } from "@/components/slideable-drawer";
 
 const Wrapper = styled("main")`
   body:has(&) {
@@ -32,7 +33,9 @@ export default function Main() {
   return (
     <Wrapper>
       <CanvasView />
-      <ActionPanel />
+      <SlideableDrawer>
+        <ActionPanel />
+      </SlideableDrawer>
     </Wrapper>
   );
 }

--- a/packages/frontend/src/components/action-panel/ActionPanel.tsx
+++ b/packages/frontend/src/components/action-panel/ActionPanel.tsx
@@ -10,8 +10,7 @@ import { PixelInfoTab, PlacePixelTab } from "./tabs";
 const Wrapper = styled("div")`
   --padding-width: 1rem;
   background-color: var(--discord-legacy-not-quite-black);
-  border-start-start-radius: var(--card-border-radius);
-  border-start-end-radius: var(--card-border-radius);
+  border-radius: var(--card-border-radius);
   border: var(--card-border);
   display: grid;
   gap: 0.5rem;
@@ -24,8 +23,9 @@ const Wrapper = styled("div")`
     border-radius: calc(var(--card-border-radius) - var(--padding-width));
   }
 
-  ${({ theme }) => theme.breakpoints.up("md")} {
-    border-radius: var(--card-border-radius);
+  ${({ theme }) => theme.breakpoints.down("md")} {
+    border-radius: 0;
+    border: initial;
   }
 `;
 

--- a/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/contexts";
 import { usePalette } from "@/hooks";
 import { decodeUserGuildsBase64 } from "@/util";
+import { useCallback, useEffect, useState } from "react";
 import { DynamicAnchorButton, PlacePixelButton } from "../../button";
 import { InteractiveSwatch } from "../../swatch";
 import { Heading } from "../ActionPanel";
@@ -16,7 +17,6 @@ import { ScrollBlock, TabBlock } from "./ActionPanelTabBody";
 import { ActionPanelTabBody } from "./ActionPanelTabBody";
 import BotCommandCard from "./BotCommandCard";
 import ColorInfoCard from "./SelectedColorInfoCard";
-import { useCallback, useEffect, useState } from "react";
 
 const ColorPicker = styled("div")`
   display: grid;

--- a/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
@@ -16,7 +16,7 @@ import { ScrollBlock, TabBlock } from "./ActionPanelTabBody";
 import { ActionPanelTabBody } from "./ActionPanelTabBody";
 import BotCommandCard from "./BotCommandCard";
 import ColorInfoCard from "./SelectedColorInfoCard";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const ColorPicker = styled("div")`
   display: grid;
@@ -68,17 +68,27 @@ export default function PlacePixelTab({
   // Boolean to hide certain elements when the tab is too small
   // Current implementation is a bit jarring when things pop in and out
   const [isLarge, setIsLarge] = useState(true);
-  const PlacePixelTabBlockRef = useCallback((elem: HTMLDivElement | null) => {
-    const remPixels = Number.parseFloat(
-      getComputedStyle(document.documentElement).fontSize,
+
+  // Get value of the rem in pixels (and only run it client-side)
+  const [remPixels, setRemPixels] = useState<number>(16);
+  useEffect(() => {
+    // This runs only in the browser after hydration
+    setRemPixels(
+      Number.parseFloat(getComputedStyle(document.documentElement).fontSize),
     );
-    if (!elem) return;
-    const resizeObserver = new ResizeObserver((entries) => {
-      const height = entries[0].target.clientHeight;
-      setIsLarge(height > remPixels * 20);
-    });
-    resizeObserver.observe(elem);
   }, []);
+
+  const PlacePixelTabBlockRef = useCallback(
+    (elem: HTMLDivElement | null) => {
+      if (!elem) return;
+      const resizeObserver = new ResizeObserver((entries) => {
+        const height = entries[0].target.clientHeight;
+        setIsLarge(height > remPixels * 20);
+      });
+      resizeObserver.observe(elem);
+    },
+    [remPixels],
+  );
 
   const { color: selectedColor, setColor: setSelectedColor } =
     useSelectedColorContext();

--- a/packages/frontend/src/components/button/PlacePixelButton.tsx
+++ b/packages/frontend/src/components/button/PlacePixelButton.tsx
@@ -17,7 +17,11 @@ export const CoordinateLabel = styled("span")`
   opacity: 0.6;
 `;
 
-export default function PlacePixelButton() {
+interface PlacePixelButtonProps {
+  isVerbose: boolean;
+}
+
+export default function PlacePixelButton({ isVerbose }: PlacePixelButtonProps) {
   const { canvas, coords, adjustedCoords, setCoords } = useCanvasContext();
   const { color } = useSelectedColorContext();
   const isSelected = adjustedCoords && color;
@@ -120,9 +124,12 @@ export default function PlacePixelButton() {
   const { x, y } = adjustedCoords;
   const nbsp = "\u00A0";
 
+  const placePixelMessege =
+    isVerbose ? `Place ${color.code} at` : "Place pixel";
+
   return (
     <DynamicButton color={color} onAction={handlePixelRequest}>
-      {isSelected ? "Place pixel" : "Select a pixel"}
+      {isSelected ? placePixelMessege : "Select a pixel"}
       {isSelected && (
         <CoordinateLabel>
           {/* String interpolation is required to prevent https://github.com/UOA-CS732-SE750-Students-2024/project-group-golden-giraffes/issues/255 */}

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -25,6 +25,7 @@ const CanvasContainer = styled("div")`
   border-radius: var(--card-border-radius);
   border: var(--card-border);
   display: flex;
+  grid-row: 1 / -1;
   overflow: hidden;
   place-content: center;
   place-items: center;
@@ -39,8 +40,8 @@ const CanvasContainer = styled("div")`
     user-select: none;
   }
 
-  ${({ theme }) => theme.breakpoints.up("md")} {
-    grid-row: 1 / -1;
+  ${({ theme }) => theme.breakpoints.down("md")} {
+    border-radius: 0;
   }
 
   :active {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -77,7 +77,6 @@ const InviteButton = styled(Button)`
     from var(--discord-legacy-dark-but-not-black) l c h / 80%
   );
   border-radius: 0.5rem 0.5rem 1rem 0.5rem;
-  bottom: 0.5rem;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   color: white;
   font-size: 1.2rem;
@@ -91,6 +90,14 @@ const InviteButton = styled(Button)`
 
   :hover {
     background-color: var(--discord-blurple);
+  }
+
+  ${({ theme }) => theme.breakpoints.up("md")} {
+    bottom: 0.5rem;
+  }
+
+  ${({ theme }) => theme.breakpoints.down("md")} {
+    top: 0.5rem;
   }
 `;
 

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -35,7 +35,7 @@ const DrawerWrapper = styled("div")<{ drawerHeight: number }>`
 
 const HandleWrapper = styled("div")`
   cursor: grab;
-  padding-block: 0.4rem 0;
+  padding-block: 0.8rem 0;
   padding-inline: auto;
   display: flex;
   place-content: center;
@@ -61,9 +61,8 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
    * Defaults to pan when a single pointer is down, and zoom when two pointers are down.
    */
   const handlePointerMove = useCallback((event: PointerEvent): void => {
-    const elem = event.currentTarget;
-    // Only handle primary pointers to prevent duplicate handling
-    if (!(elem instanceof HTMLElement)) return;
+    // Shouldn't occur, but don't handle non-primary pointers
+    if (!event.isPrimary) return;
     setDrawerHeight((prevHeight) => prevHeight + event.movementY);
   }, []);
 
@@ -106,11 +105,11 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
     <>
       {/* Doing it this way as handlers are directly applied to DrawerWrapper (though it could also be possible to dynamically disable them through code) */}
       <DrawerWrapper
-        onPointerDown={handlePointerDown}
         drawerHeight={drawerHeight}
         style={{ height: `calc(50% - ${drawerHeight}px)` }}
       >
-        <HandleWrapper>
+        {/* Looked at drawers from both Apple and Google, and they both work on the entire drawer instead of just the handle, but the overflow behaviour is a bit weird to get right */}
+        <HandleWrapper onPointerDown={handlePointerDown}>
           <Handle />
         </HandleWrapper>
         {children}

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { styled } from "@mui/material";
+
+const Wrapper = styled("div")`
+  ${({ theme }) => theme.breakpoints.down("md")} {
+    display: none;
+  }
+`;
+
+const DrawerWrapper = styled("div")`
+  ${({ theme }) => theme.breakpoints.up("md")} {
+    display: none;
+  }
+
+  /* Styling for action panel in drawer mode */
+  ${({ theme }) => theme.breakpoints.down("md")} {
+    border-radius: var(--card-border-radius);
+    border: var(--card-border);
+    background-color: var(--discord-legacy-not-quite-black);
+
+    position: absolute;
+    width: 100%;
+    height: 50%;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    bottom: 0;
+  }
+  & > * {
+    flex-grow: 1;
+  }
+`;
+
+const HandleWrapper = styled("div")`
+  cursor: grab;
+  padding-block: 0.4rem 0;
+  padding-inline: auto;
+  display: flex;
+  place-content: center;
+  flex-grow: 0;
+`;
+
+const Handle = styled("div")`
+  background-color: var(--discord-white);
+  border-radius: 0.2rem;
+  width: 4rem;
+  height: 0.4rem;
+`;
+
+interface SlideableDrawerProps {
+  children: React.ReactNode;
+}
+
+export default function SlideableDrawer({ children }: SlideableDrawerProps) {
+  return (
+    <>
+      {/* Doing it this way as handlers are directly applied to DrawerWrapper (though it could also be possible to dynamically disable them through code) */}
+      <DrawerWrapper>
+        <HandleWrapper>
+          <Handle />
+        </HandleWrapper>
+        {children}
+      </DrawerWrapper>
+      <Wrapper>{children}</Wrapper>
+    </>
+  );
+}

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -32,7 +32,6 @@ const DrawerWrapper = styled("div")<{ drawerHeight: number }>`
     }
   }
   & > * {
-    flex-grow: 1;
     /* Only applied to the top level elements that aren't scrollable */
     /* I can envision a more hacky way to apply it to all children if desired*/
     touch-action: none;
@@ -45,8 +44,6 @@ const HandleWrapper = styled("div")`
   padding-inline: auto;
   display: flex;
   place-content: center;
-  /* Hacky, overwrites the flex-grow from DrawerWrapper */
-  flex-grow: 0 !important;
 `;
 
 const Handle = styled("div")`

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -159,7 +159,20 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
     (event: React.PointerEvent<HTMLDivElement>) => {
       // Only handle primary pointers
       if (!event.isPrimary) return;
-      // const elemTarget = event.target;
+      const currentTarget = event.currentTarget;
+      let elemTarget: EventTarget | null = event.target;
+      if (!(currentTarget instanceof HTMLElement)) {
+        return;
+      }
+      // Loop through all parents of the target until until current target to find if target is scrollable
+      while (currentTarget !== elemTarget) {
+        if (!(elemTarget instanceof HTMLElement)) return;
+        // If target is scrollable past an arbitrary threshold, then don't resize drawer
+        if (elemTarget.scrollHeight - elemTarget.clientHeight > 5) {
+          return;
+        }
+        elemTarget = elemTarget.parentElement;
+      }
 
       const elem = event.currentTarget;
       elem.setPointerCapture(event.pointerId);
@@ -177,9 +190,9 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
         drawerHeight={drawerHeight}
         style={{ height: `${drawerHeight}px` }}
         ref={drawerWrapperRef}
+        onPointerDown={handlePointerDown}
       >
-        {/* Looked at drawers from both Apple and Google, and they both work on the entire drawer instead of just the handle, but the overflow behaviour is a bit weird to get right */}
-        <HandleWrapper onPointerDown={handlePointerDown}>
+        <HandleWrapper>
           <Handle />
         </HandleWrapper>
         {children}

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -26,6 +26,10 @@ const DrawerWrapper = styled("div")<{ drawerHeight: number }>`
     flex-direction: column;
     gap: 0;
     bottom: 0;
+    transition: height 0.5s ease;
+    &:active {
+      transition: none;
+    }
   }
   & > * {
     flex-grow: 1;
@@ -74,6 +78,7 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
       const elem = event.currentTarget;
       if (!(elem instanceof HTMLElement)) return;
       elem.releasePointerCapture(event.pointerId);
+      setDrawerHeight(0);
 
       elem.removeEventListener("pointermove", handlePointerMove);
       elem.removeEventListener("pointerup", handlePointerUp);

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { styled } from "@mui/material";
+import { useCallback } from "react";
 
 const Wrapper = styled("div")`
   ${({ theme }) => theme.breakpoints.down("md")} {
@@ -53,10 +54,51 @@ interface SlideableDrawerProps {
 }
 
 export default function SlideableDrawer({ children }: SlideableDrawerProps) {
+  /**
+   * Defaults to pan when a single pointer is down, and zoom when two pointers are down.
+   */
+  const handlePointerMove = useCallback((event: PointerEvent): void => {
+    const elem = event.currentTarget;
+    // Only handle primary pointers to prevent duplicate handling
+    if (!(elem instanceof HTMLElement)) return;
+    console.log(event.movementX);
+  }, []);
+
+  /**
+   * Remove the listeners when the mouse is released to stop panning.
+   */
+  const handlePointerUp = useCallback(
+    (event: PointerEvent): void => {
+      const elem = event.currentTarget;
+      if (!(elem instanceof HTMLElement)) return;
+      elem.releasePointerCapture(event.pointerId);
+
+      elem.removeEventListener("pointermove", handlePointerMove);
+      elem.removeEventListener("pointerup", handlePointerUp);
+      elem.removeEventListener("pointercancel", handlePointerUp);
+    },
+    [handlePointerMove],
+  );
+
+  /**
+   * Only add the mouse move listener when you click down so that moving your mouse normally doesn't
+   * cause the canvas to pan.
+   */
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const elem = event.currentTarget;
+      elem.setPointerCapture(event.pointerId);
+      elem.addEventListener("pointermove", handlePointerMove);
+      elem.addEventListener("pointerup", handlePointerUp);
+      elem.addEventListener("pointercancel", handlePointerUp);
+    },
+    [handlePointerMove, handlePointerUp],
+  );
+
   return (
     <>
       {/* Doing it this way as handlers are directly applied to DrawerWrapper (though it could also be possible to dynamically disable them through code) */}
-      <DrawerWrapper>
+      <DrawerWrapper onPointerDown={handlePointerDown}>
         <HandleWrapper>
           <Handle />
         </HandleWrapper>

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -79,45 +79,45 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
     getComputedStyle(document.documentElement).fontSize,
   );
   // Kinda just eyeballed the 6 rem to be the smallest as it looked ok.
-  const pointerBoundaries: CssValue[] = [
+  const pointerBounds: CssValue[] = [
     { type: "Rem", value: 6 },
     { type: "Percentage", value: 50 },
     { type: "Percentage", value: 90 },
   ];
 
-  const convertBoundaryToPixels = useCallback(
-    (boundary: CssValue, maxHeight: number) => {
-      switch (boundary.type) {
+  const convertBoundToPixels = useCallback(
+    (bound: CssValue, maxHeight: number) => {
+      switch (bound.type) {
         case "Rem":
-          return boundary.value * remPixels;
+          return bound.value * remPixels;
         case "Percentage":
-          return (boundary.value * maxHeight) / 100;
+          return (bound.value * maxHeight) / 100;
       }
     },
     [remPixels],
   );
 
-  const snapToBoundaries = useCallback(
+  const snapToBounds = useCallback(
     (height: number) => {
       // Convert boundary values to pixel values
-      const boundaryPixels = pointerBoundaries.map((boundary) =>
-        convertBoundaryToPixels(boundary, maxHeight),
+      const boundsPixels = pointerBounds.map((bound) =>
+        convertBoundToPixels(bound, maxHeight),
       );
       // End loop at one before the last element. Returns the nearest boundary
-      for (let i = 0; i < boundaryPixels.length - 1; i++) {
-        if (height < (boundaryPixels[i] + boundaryPixels[i + 1]) / 2) {
-          return boundaryPixels[i];
+      for (let i = 0; i < boundsPixels.length - 1; i++) {
+        if (height < (boundsPixels[i] + boundsPixels[i + 1]) / 2) {
+          return boundsPixels[i];
         }
       }
-      return boundaryPixels[boundaryPixels.length - 1];
+      return boundsPixels[boundsPixels.length - 1];
     },
-    [maxHeight, convertBoundaryToPixels],
+    [maxHeight, convertBoundToPixels],
   );
 
   // Set the initial height
   useEffect(() => {
-    setDrawerHeight((prevHeight) => snapToBoundaries(prevHeight));
-  }, [snapToBoundaries]);
+    setDrawerHeight((prevHeight) => snapToBounds(prevHeight));
+  }, [snapToBounds]);
 
   /**
    * Defaults to pan when a single pointer is down, and zoom when two pointers are down.
@@ -138,14 +138,14 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
       elem.releasePointerCapture(event.pointerId);
 
       setDrawerHeight((prevHeight) => {
-        return snapToBoundaries(prevHeight);
+        return snapToBounds(prevHeight);
       });
 
       elem.removeEventListener("pointermove", handlePointerMove);
       elem.removeEventListener("pointerup", handlePointerUp);
       elem.removeEventListener("pointercancel", handlePointerUp);
     },
-    [handlePointerMove, snapToBoundaries],
+    [handlePointerMove, snapToBounds],
   );
 
   /**

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { styled } from "@mui/material";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const Wrapper = styled("div")`
   ${({ theme }) => theme.breakpoints.down("md")} {
@@ -59,7 +59,16 @@ interface SlideableDrawerProps {
 }
 
 export default function SlideableDrawer({ children }: SlideableDrawerProps) {
+  const drawerWrapperRef = useRef<HTMLDivElement>(null);
   const [drawerHeight, setDrawerHeight] = useState(0);
+
+  // Set the height of the drawer to half the canvas height
+  useEffect(() => {
+    if (drawerWrapperRef.current?.parentElement) {
+      console.log(drawerWrapperRef.current.parentElement.clientHeight);
+      setDrawerHeight(drawerWrapperRef.current.parentElement?.clientHeight / 2);
+    }
+  }, []);
 
   /**
    * Defaults to pan when a single pointer is down, and zoom when two pointers are down.
@@ -67,7 +76,7 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
   const handlePointerMove = useCallback((event: PointerEvent): void => {
     // Shouldn't occur, but don't handle non-primary pointers
     if (!event.isPrimary) return;
-    setDrawerHeight((prevHeight) => prevHeight + event.movementY);
+    setDrawerHeight((prevHeight) => prevHeight - event.movementY);
   }, []);
 
   /**
@@ -78,7 +87,6 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
       const elem = event.currentTarget;
       if (!(elem instanceof HTMLElement)) return;
       elem.releasePointerCapture(event.pointerId);
-      setDrawerHeight(0);
 
       elem.removeEventListener("pointermove", handlePointerMove);
       elem.removeEventListener("pointerup", handlePointerUp);
@@ -111,7 +119,8 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
       {/* Doing it this way as handlers are directly applied to DrawerWrapper (though it could also be possible to dynamically disable them through code) */}
       <DrawerWrapper
         drawerHeight={drawerHeight}
-        style={{ height: `calc(50% - ${drawerHeight}px)` }}
+        style={{ height: `${drawerHeight}px` }}
+        ref={drawerWrapperRef}
       >
         {/* Looked at drawers from both Apple and Google, and they both work on the entire drawer instead of just the handle, but the overflow behaviour is a bit weird to get right */}
         <HandleWrapper onPointerDown={handlePointerDown}>

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -73,10 +73,16 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
   }, []);
 
   const [drawerHeight, setDrawerHeight] = useState(0);
-  // Get value of rem in pixels
-  const remPixels = Number.parseFloat(
-    getComputedStyle(document.documentElement).fontSize,
-  );
+
+  // Get value of the rem in pixels (and only run it client-side)
+  const [remPixels, setRemPixels] = useState<number>(16);
+  useEffect(() => {
+    // This runs only in the browser after hydration
+    setRemPixels(
+      Number.parseFloat(getComputedStyle(document.documentElement).fontSize),
+    );
+  }, []);
+
   // Kinda just eyeballed the 6 and 3.75 rem and it looked ok.
   const pointerBounds: CssValue[] = [
     { type: "Rem", value: 6 },

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -86,13 +86,15 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
   ];
 
   const convertBoundToPixels = useCallback(
-    (bound: CssValue, maxHeight: number) => {
-      switch (bound.type) {
-        case "Rem":
-          return bound.value * remPixels;
-        case "Percentage":
-          return (bound.value * maxHeight) / 100;
-      }
+    (maxHeight: number) => {
+      return pointerBounds.map((bound) => {
+        switch (bound.type) {
+          case "Rem":
+            return bound.value * remPixels;
+          case "Percentage":
+            return (bound.value * maxHeight) / 100;
+        }
+      });
     },
     [remPixels],
   );
@@ -100,9 +102,7 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
   const snapToBounds = useCallback(
     (height: number) => {
       // Convert boundary values to pixel values
-      const boundsPixels = pointerBounds.map((bound) =>
-        convertBoundToPixels(bound, maxHeight),
-      );
+      const boundsPixels = convertBoundToPixels(maxHeight);
       // End loop at one before the last element. Returns the nearest boundary
       for (let i = 0; i < boundsPixels.length - 1; i++) {
         if (height < (boundsPixels[i] + boundsPixels[i + 1]) / 2) {

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -33,6 +33,8 @@ const DrawerWrapper = styled("div")<{ drawerHeight: number }>`
   }
   & > * {
     flex-grow: 1;
+    /* Only applied to the top level elements that aren't scrollable */
+    /* I can envision a more hacky way to apply it to all children if desired*/
     touch-action: none;
   }
 `;
@@ -185,7 +187,7 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
 
   return (
     <>
-      {/* Doing it this way as handlers are directly applied to DrawerWrapper (though it could also be possible to dynamically disable them through code) */}
+      {/* Duplicating DrawerWrapper and Wrapper as handlers are directly applied to DrawerWrapper (though it could also be possible to dynamically disable them through code) */}
       <DrawerWrapper
         drawerHeight={drawerHeight}
         style={{ height: `${drawerHeight}px` }}

--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -78,11 +78,11 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
   const remPixels = Number.parseFloat(
     getComputedStyle(document.documentElement).fontSize,
   );
-  // Kinda just eyeballed the 6 rem to be the smallest as it looked ok.
+  // Kinda just eyeballed the 6 and 3.75 rem and it looked ok.
   const pointerBounds: CssValue[] = [
     { type: "Rem", value: 6 },
     { type: "Percentage", value: 50 },
-    { type: "Percentage", value: 90 },
+    { type: "Rem", value: -3.75 },
   ];
 
   const convertBoundToPixels = useCallback(
@@ -90,6 +90,9 @@ export default function SlideableDrawer({ children }: SlideableDrawerProps) {
       return pointerBounds.map((bound) => {
         switch (bound.type) {
           case "Rem":
+            if (bound.value < 0) {
+              return maxHeight + bound.value * remPixels;
+            }
             return bound.value * remPixels;
           case "Percentage":
             return (bound.value * maxHeight) / 100;

--- a/packages/frontend/src/components/slideable-drawer/index.ts
+++ b/packages/frontend/src/components/slideable-drawer/index.ts
@@ -1,0 +1,1 @@
+export { default as SlideableDrawer } from "./SlideableDrawer";


### PR DESCRIPTION
Tested on an iOS simulator on iPhone16

Adds a drawer that slides between three stages of openedness.
Drawer can be slid open using the handle and also the tab bar elements (would be a bit more hacky [even more than currently] to support all non-scrollable elements such as the element for who placed the most recent pixel).

Moves the project blurple invite link onto the top right when in mobile.

Of the 3 stages of openedness:

1. Closed: only shows handle, and the Place and Look tabs
2. Half: 50%: shows everything except the Color and Discord placement commands. (Uses a verbose mode of the place pixel button that includes the color in the string. Looks a bit weird due to the proximity of the place pixel button and the colors.
3. Open: Shows everything. The transition from half to full is a bit jarring as the color indicator and the discord placement command appears out of nowhere. Specifically positioned so that the top of the drawer sits right under the project blurple invite.

Couldn't find a method to hide the toolbar on iOS Safari that worked.

Dependant on 2 PRs, which I can't really stack, which is why the commit count is a bit off.