### PR TITLE
fix: use `Math.ceil` not `Math.round` when displaying cooldown

### DIFF
--- a/packages/frontend/src/components/button/PlacePixelButton.tsx
+++ b/packages/frontend/src/components/button/PlacePixelButton.tsx
@@ -61,7 +61,7 @@ export default function PlacePixelButton({ isVerbose }: PlacePixelButtonProps) {
         const cooldown = data.cooldownEndTime;
         if (cooldown) {
           setTimeLeft(
-            Math.round((new Date(cooldown).valueOf() - Date.now()) / 1000),
+            Math.ceil((new Date(cooldown).valueOf() - Date.now()) / 1000),
           );
         }
         setIsPlacing(false);


### PR DESCRIPTION
This should reduce the number of times users accidentally try and place a pixel before they're allowed to.

I don't have time, unfortunately, but what we should be doing is throwing a 400 on the server with the number of milliseconds left. In our error block, we should wait for that number of milliseconds and then automatically try again. Providing the ms left rather than the timestamp again is important because sometimes you can have clients whose clock is out of sync with our server, which is why this happens in the first place.