### PR TITLE
fix(frontend): add mininum size to canvas image for  mobile

### DIFF
--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -677,6 +677,8 @@ export default function CanvasView() {
               ref={imageRef}
               src={imageUrl}
               crossOrigin="anonymous"
+              // Minimum width and height need to be forced to prevent incorrect clampScale and reticle placements
+              style={{ minWidth: canvas.width, minHeight: canvas.height }}
             />
           </CanvasImageWrapper>
         </div>


### PR DESCRIPTION
Fixes this issue.

https://github.com/user-attachments/assets/6be1bfa1-a5c4-4187-84fc-b6326748d4a9

