### PR TITLE
fix(frontend): eyeball styling fix for mobile leaderboard

### DIFF
--- a/packages/frontend/src/app/leaderboard/Leaderboard.tsx
+++ b/packages/frontend/src/app/leaderboard/Leaderboard.tsx
@@ -19,15 +19,15 @@ const TitleBlock = styled("div")`
 `;
 
 const Table = styled("table")`
-  font-size: 1.75rem;
+  font-size: min(4svw, 1.75rem);
   font-variant-numeric: tabular-nums;
   font-weight: 500;
-  inline-size: 40rem;
+  inline-size: min(40rem, 100svw);
   max-inline-size: 100%;
 
   th,
   td {
-    padding: 1rem;
+    padding: min(1.5svw, 1rem);
   }
 `;
 


### PR DESCRIPTION
Very scuffed fix for displaying leaderboard in mobile. I think it breaks when it sees something smaller than an iPhone size though.

![image](https://github.com/user-attachments/assets/0bfd7168-cf5e-4884-aff4-1a0a3df6c628)
