### PR TITLE
fix: use cooldown time directly instead of returning a timestamp

### DIFF
--- a/packages/backend/src/routes/api/v1/pixel.ts
+++ b/packages/backend/src/routes/api/v1/pixel.ts
@@ -116,10 +116,10 @@ pixelRouter.post<CanvasIdParam>("/", async (req, res) => {
       coordinates,
       color,
     );
-    if (!futureCooldown) return res.status(201).json({cooldownEndTime: null});
+    if (!futureCooldown) return res.status(201).json({ cooldownEndTime: null });
     return res
       .status(201)
-      .json({ cooldownEndTime: futureCooldown.valueOf() - Date.now()});
+      .json({ cooldownEndTime: futureCooldown.valueOf() - Date.now() });
   } catch (error) {
     ApiError.sendError(res, error);
   }

--- a/packages/backend/src/routes/api/v1/pixel.ts
+++ b/packages/backend/src/routes/api/v1/pixel.ts
@@ -116,10 +116,10 @@ pixelRouter.post<CanvasIdParam>("/", async (req, res) => {
       coordinates,
       color,
     );
-
+    if (!futureCooldown) return res.status(201).json({cooldownEndTime: null});
     return res
       .status(201)
-      .json({ cooldownEndTime: futureCooldown?.toISOString() ?? null });
+      .json({ cooldownEndTime: futureCooldown.valueOf() - Date.now()});
   } catch (error) {
     ApiError.sendError(res, error);
   }

--- a/packages/frontend/src/components/button/PlacePixelButton.tsx
+++ b/packages/frontend/src/components/button/PlacePixelButton.tsx
@@ -60,9 +60,7 @@ export default function PlacePixelButton({ isVerbose }: PlacePixelButtonProps) {
       .then((data) => {
         const cooldown = data.cooldownEndTime;
         if (cooldown) {
-          setTimeLeft(
-            Math.ceil((new Date(cooldown).valueOf() - Date.now()) / 1000),
-          );
+          setTimeLeft(Math.ceil(cooldown / 1000));
         }
         setIsPlacing(false);
       })

--- a/packages/types/src/cooldown.d.ts
+++ b/packages/types/src/cooldown.d.ts
@@ -1,3 +1,3 @@
 export interface Cooldown {
-  cooldownEndTime?: string;
+  cooldownEndTime?: number;
 }


### PR DESCRIPTION
Should fix #273, can't really test it since I can't desync my backend server clock with the frontend, I think. The placement thing still works though.
Doesn't really address the error 400 mentioned in the originating PR however though. also can't really rely on test cases because of, reasons...