### PR TITLE
fix(frontend): use pixel overlay together with offscreencanvas

### DIFF
--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -326,13 +326,20 @@ export default function CanvasView() {
       const [r, g, b, a] = payload.rgba;
       ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${a / 255})`;
       ctx.fillRect(payload.x, payload.y, 1, 1);
-      offscreenCanvas.convertToBlob().then((blob) => {
-        const pixelImage = new Image();
-        pixelImage.src = URL.createObjectURL(blob);
-        pixelImage.onload = () => {
-          canvasImageWrapperRef.current?.appendChild(pixelImage);
-        };
-      });
+      const start = performance.now();
+      // Keeping this there for performance testing reasons
+      const max_iter = 1000;
+      for (let i = 0; i < max_iter; i++) {
+        offscreenCanvas.convertToBlob().then((blob) => {
+          const pixelImage = new Image();
+          pixelImage.src = URL.createObjectURL(blob);
+          pixelImage.onload = () => {
+            canvasImageWrapperRef.current?.appendChild(pixelImage);
+          };
+        });
+      }
+      const end = performance.now();
+      console.log(`Conversion took ${end - start} ms`);
     };
 
     const pixelPlaceEvent = `place pixel ${canvas.id}`;

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -262,7 +262,7 @@ export default function CanvasView() {
   // Counts the number of pixels that have been overlaid over the canvas from live updates
   const overlayCountRef = useRef(0);
   // Maximum amount of pixels that can be overlaid. From testing on an M1 Pro, seems to be around 100
-  const pixelOverlayThreshold = 100;
+  const pixelOverlayThreshold = 50;
 
   const imageUrl = `${config.apiUrl}/api/v1/canvas/${canvas.id}`;
   const handleLoadImage = useCallback(

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -262,7 +262,7 @@ export default function CanvasView() {
   // Counts the number of pixels that have been overlaid over the canvas from live updates
   const overlayCountRef = useRef(0);
   // Maximum amount of pixels that can be overlaid. From testing on an M1 Pro, seems to be around 100
-  const maxPixelOvelayAmount = 100;
+  const pixelOverlayThreshold = 100;
 
   const imageUrl = `${config.apiUrl}/api/v1/canvas/${canvas.id}`;
   const handleLoadImage = useCallback(
@@ -347,7 +347,7 @@ export default function CanvasView() {
 
       // This method prevents the need to convert an N×M canvas to a png on every update
       // while also preventing an inordinate amount of overlaid pixels from causing lag
-      if (overlayCountRef.current >= maxPixelOvelayAmount) {
+      if (overlayCountRef.current >= pixelOverlayThreshold) {
         // flush the overlayed pixels and update canvas image
         clearOverlay();
         offscreenCanvasRef.current?.convertToBlob().then((blob) => {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -407,7 +407,6 @@ export default function CanvasView() {
     // Keep this in mind when testing for performance.
     const canvasImageWrapper = canvasImageWrapperRef.current;
     if (!canvasImageWrapper) return;
-    console.log(canvasImageWrapper.children.length);
     // Clears all overlayed pixels and retains the original image
     while (canvasImageWrapper.children.length > 1) {
       const lastChild = canvasImageWrapper.lastChild;

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -259,8 +259,10 @@ export default function CanvasView() {
   // const canvasCtxRef = useRef<OffscreenCanvasRenderingContext2D | null>(null);
   const offscreenCanvasRef = useRef<OffscreenCanvas | null>(null);
   const currentCanvasIDRef = useRef(0);
+  // Counts the number of pixels that have been overlaid over the canvas from live updates
   const overlayCountRef = useRef(0);
-  const maxPixelOvelayAmount = 99;
+  // Maximum amount of pixels that can be overlaid. From testing on an M1 Pro, seems to be around 100
+  const maxPixelOvelayAmount = 100;
 
   const imageUrl = `${config.apiUrl}/api/v1/canvas/${canvas.id}`;
   const handleLoadImage = useCallback(
@@ -402,7 +404,13 @@ export default function CanvasView() {
     };
   }, [canvas]);
 
+  /**
+   * Clears all overlayed pixels from the canvas image wrapper
+   */
   const clearOverlay = () => {
+    // canvasImageWrapper.children only gets populated per DOM update.
+    // This means that if the pixels are overlaid in a for loop, `clearOverlay` doesn't run during the loop.
+    // Keep this in mind when testing for performance.
     const canvasImageWrapper = canvasImageWrapperRef.current;
     if (!canvasImageWrapper) return;
     console.log(canvasImageWrapper.children.length);

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -265,9 +265,7 @@ export default function CanvasView() {
   const imageUrl = `${config.apiUrl}/api/v1/canvas/${canvas.id}`;
   const handleLoadImage = useCallback(
     (image: HTMLImageElement): void => {
-      console.log(currentCanvasIDRef.current, canvas.id);
       if (currentCanvasIDRef.current === canvas.id) return;
-      console.log("Loading new image");
       currentCanvasIDRef.current = canvas.id;
       const zoom =
         containerRef.current ? getDefaultZoom(containerRef.current, image) : 1;


### PR DESCRIPTION
Fixes the performance issues experienced by users when live updating places too many pixels.

Generally start experiencing lag around 100+ overlaid pixels. Solution is the prevent the accumulation of over 100 pixels. There is a variable to adjust the threshold in case lower-end devices can't handle it. See: `pixelOverlayThreshold`.

commit f4665c94c7ae237b518dda7032e8a6a2aafaa786 adds a loop to spoof 1000 places per real placed pixel. 

commit 7fcb56e302ad24b2f633125751d7ccc9a244944b implements a first fix that updates an offscreen canvas which is then converted into a png. Performance testing of 1000 places per pixels is also implemented here.

Use commit 94697ff0cc957d09c3566c41c25966490d9c43b4 to test the performance of the last fix, which combines both of the previous methods above. Only spoofs 100 pixels due to the limitations of React (explained in the code comments and documentation).