### PR TITLE
fix(frontend): inconsistent panning based on browser

### DIFF
--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -186,15 +186,25 @@ function calculateTouchOffsetDelta(
 ) {
   if (event1 === undefined || event2 === undefined)
     return { offset: undefined, scale: undefined, centerOffset: undefined };
+
+  const previousEvent1 = previousPointerEvents.get(event1.pointerId);
+  const previousEvent2 = previousPointerEvents.get(event2.pointerId);
+  if (!previousEvent1 || !previousEvent2)
+    return { offset: undefined, scale: undefined, centerOffset: undefined };
+
   const oldPosition1 = getRelativePointerPosition(elem, event1);
   const oldPosition2 = getRelativePointerPosition(elem, event2);
+
+  const movementDelta1 = getMovementDelta(previousEvent1, event1);
+  const movementDelta2 = getMovementDelta(previousEvent2, event2);
+
   const newPosition1 = addPoints(oldPosition1, {
-    x: event1.movementX,
-    y: event1.movementY,
+    x: movementDelta1.x,
+    y: movementDelta1.y,
   });
   const newPosition2 = addPoints(oldPosition2, {
-    x: event2.movementX,
-    y: event2.movementY,
+    x: movementDelta2.x,
+    y: movementDelta2.y,
   });
   const oldMagitude = distanceBetweenPoints(oldPosition1, oldPosition2);
   const newMagitude = distanceBetweenPoints(newPosition1, newPosition2);
@@ -203,8 +213,8 @@ function calculateTouchOffsetDelta(
     2,
   );
   const offsetDelta = {
-    x: (event1.movementX + event2.movementX) / 2,
-    y: (event1.movementY + event2.movementY) / 2,
+    x: movementDelta1.x + movementDelta2.x / 2,
+    y: movementDelta1.y + movementDelta2.y / 2,
   };
   const scale = newMagitude / oldMagitude;
   return { offsetDelta, scale, centerOffset: relativePosition };

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -166,6 +166,17 @@ function getRelativePointerPosition(element: HTMLElement, event: MouseEvent) {
 }
 
 /**
+ * Relpaces the usage of PointerEvent.movementX and PointerEvent.movementY due to issues outlined in
+ * https://github.com/w3c/pointerlock/issues/42#issuecomment-1886587107
+ */
+function getMovementDelta(prevEvent: PointerEvent, event: PointerEvent) {
+  return {
+    x: event.clientX - prevEvent.clientX,
+    y: event.clientY - prevEvent.clientY,
+  };
+}
+
+/**
  * Calculates the various variables required to get pan pinch working
  */
 function calculateTouchOffsetDelta(
@@ -536,16 +547,6 @@ export default function CanvasView() {
     [clampOffset],
   );
 
-  const getMovementDelta = useCallback(
-    (prevEvent: PointerEvent, event: PointerEvent) => {
-      return {
-        x: event.clientX - prevEvent.clientX,
-        y: event.clientY - prevEvent.clientY,
-      };
-    },
-    [],
-  );
-
   const handlePan = useCallback(
     (offsetDelta: { x: number; y: number }): void => {
       // Disable transitions while panning
@@ -591,7 +592,7 @@ export default function CanvasView() {
         handlePan(movementDelta);
       }
     },
-    [handlePan, handleZoom, getMovementDelta],
+    [handlePan, handleZoom],
   );
 
   /**

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -16,8 +16,8 @@ import {
   diffPoints,
   distanceBetweenPoints,
   dividePoint,
-  multiplyPoint,
   getMovementDelta,
+  multiplyPoint,
 } from "./point";
 
 const CanvasContainer = styled("div")`

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -601,6 +601,7 @@ export default function CanvasView() {
   const handlePointerUp = useCallback(
     (event: PointerEvent): void => {
       pointerEvents.delete(event.pointerId);
+      previousPointerEvents.delete(event.pointerId);
       const elem = event.currentTarget;
       if (!(elem instanceof HTMLElement)) return;
       elem.releasePointerCapture(event.pointerId);

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -17,6 +17,7 @@ import {
   distanceBetweenPoints,
   dividePoint,
   multiplyPoint,
+  getMovementDelta,
 } from "./point";
 
 const CanvasContainer = styled("div")`
@@ -163,17 +164,6 @@ function getDefaultZoom(
 function getRelativePointerPosition(element: HTMLElement, event: MouseEvent) {
   const rect = element.getBoundingClientRect();
   return { x: event.clientX - rect.left, y: event.clientY - rect.top };
-}
-
-/**
- * Relpaces the usage of PointerEvent.movementX and PointerEvent.movementY due to issues outlined in
- * https://github.com/w3c/pointerlock/issues/42#issuecomment-1886587107
- */
-function getMovementDelta(prevEvent: PointerEvent, event: PointerEvent) {
-  return {
-    x: event.clientX - prevEvent.clientX,
-    y: event.clientY - prevEvent.clientY,
-  };
 }
 
 /**

--- a/packages/frontend/src/components/canvas/point.ts
+++ b/packages/frontend/src/components/canvas/point.ts
@@ -37,3 +37,14 @@ export function tupleToPoint([x, y]: [number, number]): Point {
 export function distanceBetweenPoints(p1: Point, p2: Point): number {
   return Math.sqrt((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2);
 }
+
+/**
+ * Relpaces the usage of PointerEvent.movementX and PointerEvent.movementY due to issues outlined in
+ * https://github.com/w3c/pointerlock/issues/42#issuecomment-1886587107
+ */
+export function getMovementDelta(prevEvent: PointerEvent, event: PointerEvent) {
+  return {
+    x: event.clientX - prevEvent.clientX,
+    y: event.clientY - prevEvent.clientY,
+  };
+}


### PR DESCRIPTION
Especially big reason on android firefox due for some reason.

Issue is caused by the usage of PointerEvent.movementX and PointerEvent.movementY, which is inconsistent across the different browsers (Safari, Android Firefox). Fix includes a custom movementX and movementY calculation.

https://github.com/w3c/pointerlock/issues/42
https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/movementX