### PR TITLE
fix(frontend): add `display: content` to SlideableDrawer

### DIFF
--- a/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
+++ b/packages/frontend/src/components/slideable-drawer/SlideableDrawer.tsx
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { getMovementDelta } from "../canvas/point";
 
 const Wrapper = styled("div")`
+  /* Consider this a direct child of Main, which fixes scoll overflow not working */
+  display: contents;
   ${({ theme }) => theme.breakpoints.down("md")} {
     display: none;
   }


### PR DESCRIPTION
Debugged with ChatGPT, comment is my own though. Fixes scroll overflow not occurring when viewing pixel history on desktop.