### PR TITLE
fix: git ignore prisma migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Generated code
 **/node_modules/
 **/.pnp
+**/migrations/
 .pnp.js
 .yarn/install-state.gz
 


### PR DESCRIPTION
Added a `.gitingore` line about backend's Prisma migrations made via [`prisma migrate`](https://www.prisma.io/docs/orm/prisma-migrate/getting-started)