### PR TITLE
feat: Upgraded URL to include canvas, coordinates, and zoom

### DIFF
--- a/packages/frontend/src/app/canvas/[canvasId]/page.tsx
+++ b/packages/frontend/src/app/canvas/[canvasId]/page.tsx
@@ -1,0 +1,6 @@
+import Main from "../../../app/Main";
+import LayoutWithHeader from "../../../components/LayoutWithNavbar";
+
+export default function CanvasPage() {
+  return <LayoutWithHeader content={<Main />} />;
+}

--- a/packages/frontend/src/components/action-panel/tabs/ActionPanelTooltip.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/ActionPanelTooltip.tsx
@@ -1,0 +1,40 @@
+import { Tooltip, TooltipProps } from "@mui/material";
+
+interface ActionPanelTooltipProps extends Omit<
+  TooltipProps,
+  "placement" | "slotProps"
+> {
+  children: React.ReactElement;
+}
+
+export default function ActionPanelTooltip({
+  children,
+  ...props
+}: ActionPanelTooltipProps) {
+  return (
+    <Tooltip
+      placement="top"
+      slotProps={{
+        popper: {
+          modifiers: [
+            {
+              name: "offset",
+              options: {
+                offset: [0, -10],
+              },
+            },
+          ],
+        },
+        tooltip: {
+          sx: {
+            bgcolor: "var(--discord-legacy-dark-but-not-black);",
+            boxShadow: "0px 0px 5px rgba(0, 0, 0, 0.25)",
+          },
+        },
+      }}
+      {...props}
+    >
+      {children}
+    </Tooltip>
+  );
+}

--- a/packages/frontend/src/components/action-panel/tabs/ActionPanelTooltip.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/ActionPanelTooltip.tsx
@@ -1,11 +1,6 @@
 import { Tooltip, TooltipProps } from "@mui/material";
 
-interface ActionPanelTooltipProps extends Omit<
-  TooltipProps,
-  "placement" | "slotProps"
-> {
-  children: React.ReactElement;
-}
+type ActionPanelTooltipProps = Omit<TooltipProps, "placement" | "slotProps">;
 
 export default function ActionPanelTooltip({
   children,
@@ -28,7 +23,7 @@ export default function ActionPanelTooltip({
         tooltip: {
           sx: {
             bgcolor: "var(--discord-legacy-dark-but-not-black);",
-            boxShadow: "0px 0px 5px rgba(0, 0, 0, 0.25)",
+            boxShadow: "0px 0px 5px oklch(0 0 0 / 25%)",
           },
         },
       }}

--- a/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
@@ -1,16 +1,20 @@
 import { PixelHistoryRecord } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material";
-
+import { useState } from "react";
+import { DynamicButton } from "@/components/button";
 import { useCanvasContext } from "@/contexts";
 import { usePixelHistory } from "@/hooks";
+import createPixelUrl from "@/util";
 import { Heading } from "../ActionPanel";
 import {
   ActionPanelTabBody,
   ScrollBlock,
   TabBlock,
 } from "./ActionPanelTabBody";
+import ActionPanelTooltip from "./ActionPanelTooltip";
 import CoordinatesCard from "./CoordinatesCard";
 import PixelHistoryListItem from "./PixelHistoryListItem";
+import { CoordinateLabel } from "./PlacePixelTab";
 
 const PixelInfoTabBlock = styled(TabBlock)`
   grid-template-rows: auto 1fr;
@@ -72,10 +76,32 @@ export default function PixelInfoTab({
   active = false,
   canvasId,
 }: PixelInfoTabProps) {
-  const { coords, adjustedCoords } = useCanvasContext();
+  const { adjustedCoords, canvas, containerRef, coords, zoom } =
+    useCanvasContext();
   const { data, isLoading } = usePixelHistory(canvasId, coords);
 
   const pixelHistory = data?.pixelHistory ?? [];
+
+  const [tooltipIsOpen, setTooltipIsOpen] = useState(false);
+  const closeTooltip = () => setTooltipIsOpen(false);
+  const openTooltip = () => setTooltipIsOpen(true);
+
+  const pixelURL =
+    (adjustedCoords &&
+      containerRef.current &&
+      createPixelUrl({
+        canvasId: canvasId,
+        coords: adjustedCoords,
+        pixelWidth: Math.min(
+          containerRef.current?.clientWidth / zoom,
+          canvas.width,
+        ),
+        pixelHeight: Math.min(
+          containerRef.current?.clientHeight / zoom,
+          canvas.height,
+        ),
+      })) ??
+    "";
 
   return (
     <PixelInfoTabBlock active={active}>
@@ -96,6 +122,32 @@ export default function PixelInfoTab({
           </ActionPanelTabBody>
         </ScrollBlock>
       )}
+      <ActionPanelTabBody>
+        {adjustedCoords && (
+          <ActionPanelTooltip
+            title="Copied"
+            onClose={closeTooltip}
+            open={tooltipIsOpen}
+          >
+            <DynamicButton
+              color={
+                !isLoading && pixelHistory.length > 0 ?
+                  pixelHistory[0].color
+                : null
+              }
+              onAction={() => {
+                openTooltip();
+                navigator.clipboard.writeText(pixelURL);
+              }}
+            >
+              Copy link to share pixel
+              <CoordinateLabel>
+                ({adjustedCoords.x},&nbsp;{adjustedCoords.y})
+              </CoordinateLabel>
+            </DynamicButton>
+          </ActionPanelTooltip>
+        )}
+      </ActionPanelTabBody>
     </PixelInfoTabBlock>
   );
 }

--- a/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { DynamicButton } from "@/components/button";
 import { useCanvasContext } from "@/contexts";
 import { usePixelHistory } from "@/hooks";
-import createPixelUrl from "@/util";
+import { createPixelUrl } from "@/util";
 import { Heading } from "../ActionPanel";
 import {
   ActionPanelTabBody,

--- a/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
@@ -130,17 +130,13 @@ export default function PixelInfoTab({
             open={tooltipIsOpen}
           >
             <DynamicButton
-              color={
-                !isLoading && pixelHistory.length > 0 ?
-                  pixelHistory[0].color
-                : null
-              }
+              color={pixelHistory?.[0]?.color ?? null}
               onAction={() => {
                 openTooltip();
                 navigator.clipboard.writeText(pixelURL);
               }}
             >
-              Copy link to share pixel
+              Copy pixel link
               <CoordinateLabel>
                 ({adjustedCoords.x},&nbsp;{adjustedCoords.y})
               </CoordinateLabel>

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -240,16 +240,15 @@ function calculateReticleOffset(coords: Point | null): Point {
 
 export default function CanvasView() {
   const imageRef = useRef<HTMLImageElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
   const canvasImageWrapperRef = useRef<HTMLImageElement>(null);
   const canvasPanAndZoomRef = useRef<HTMLDivElement>(null);
 
   const { color } = useSelectedColorContext();
-  const { canvas, coords, setCoords } = useCanvasContext();
+  const { canvas, containerRef, coords, zoom, setCoords, setZoom } =
+    useCanvasContext();
 
   const [isLoading, setIsLoading] = useState(true);
   const [isLaunching, setIsLaunching] = useState(true);
-  const [zoom, setZoom] = useState(1);
   const zoomRef = useRef(0);
   // Always have access to the most up to date zoom value
   zoomRef.current = zoom;
@@ -518,7 +517,7 @@ export default function CanvasView() {
 
     return () =>
       containerRef.current?.removeEventListener("wheel", handleWheel);
-  }, [handleZoom]);
+  }, [handleZoom, containerRef]);
 
   /********************************
    * PANNING FUNCTIONALITY.       *

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -248,8 +248,8 @@ function getInitialViewFromSearchParams({
     : initialZoom;
 
   const targetPoint = {
-    x: canvasX - canvas.startCoordinates[0],
-    y: canvasY - canvas.startCoordinates[1],
+    x: clamp(canvasX - canvas.startCoordinates[0], 0, canvas.width - 1),
+    y: clamp(canvasY - canvas.startCoordinates[1], 0, canvas.height - 1),
   };
 
   const offset = {
@@ -397,7 +397,10 @@ export default function CanvasView() {
     }
 
     hasAppliedInitialCanvasRef.current = true;
-    void setCanvas(targetCanvasId);
+    void setCanvas(targetCanvasId).catch(() => {
+      // If URL canvas does not exist, keep default canvas and never apply URL pan/zoom.
+      hasAppliedInitialViewRef.current = true;
+    });
   }, [canvas.id, setCanvas]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We want to show the loader when switching canvases

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -231,25 +231,34 @@ function getInitialViewFromSearchParams({
 
   if (canvasX === null || canvasY === null) return null;
 
-  const targetZoom =
-    params.zoom !== null ? clampZoom(params.zoom, initialZoom)
-    : params.pixelWidth !== null || params.pixelHeight !== null ?
-      clampZoom(
-        Math.min(
-          params.pixelWidth !== null ?
-            container.clientWidth / params.pixelWidth
-          : Number.POSITIVE_INFINITY,
-          params.pixelHeight !== null ?
-            container.clientHeight / params.pixelHeight
-          : Number.POSITIVE_INFINITY,
-        ),
-        initialZoom,
-      )
-    : initialZoom;
+  const zoomFromQuery = params.zoom;
+  const hasPixelDimensions =
+    params.pixelWidth !== null || params.pixelHeight !== null;
+
+  let targetZoom = initialZoom;
+
+  if (zoomFromQuery !== null) {
+    targetZoom = clampZoom(zoomFromQuery, initialZoom);
+  } else if (hasPixelDimensions) {
+    const widthBasedZoom =
+      params.pixelWidth !== null ?
+        container.clientWidth / params.pixelWidth
+      : Number.POSITIVE_INFINITY;
+
+    const heightBasedZoom =
+      params.pixelHeight !== null ?
+        container.clientHeight / params.pixelHeight
+      : Number.POSITIVE_INFINITY;
+
+    const fitZoom = Math.min(widthBasedZoom, heightBasedZoom);
+    targetZoom = clampZoom(fitZoom, initialZoom);
+  }
+
+  const [startX, startY] = canvas.startCoordinates;
 
   const targetPoint = {
-    x: clamp(canvasX - canvas.startCoordinates[0], 0, canvas.width - 1),
-    y: clamp(canvasY - canvas.startCoordinates[1], 0, canvas.height - 1),
+    x: clamp(canvasX - startX, 0, canvas.width - 1),
+    y: clamp(canvasY - startY, 0, canvas.height - 1),
   };
 
   const offset = {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -295,7 +295,7 @@ export default function CanvasView() {
   const canvasPanAndZoomRef = useRef<HTMLDivElement>(null);
 
   const { color } = useSelectedColorContext();
-  const { canvas, containerRef, coords, zoom, setCoords, setZoom } =
+  const { canvas, containerRef, coords, zoom, setCanvas, setCoords, setZoom } =
     useCanvasContext();
 
   const [isLoading, setIsLoading] = useState(true);
@@ -336,10 +336,15 @@ export default function CanvasView() {
       setInitialZoom(zoom);
 
       let appliedInitialView = false;
+      const params = initialCanvasSearchParamsRef.current;
+      const shouldApplyInitialViewForCurrentCanvas =
+        params.canvasId === null || params.canvasId === canvas.id;
 
-      if (!hasAppliedInitialViewRef.current) {
+      if (
+        !hasAppliedInitialViewRef.current &&
+        shouldApplyInitialViewForCurrentCanvas
+      ) {
         const container = containerRef.current;
-        const params = initialCanvasSearchParamsRef.current;
 
         if (container) {
           const initialView = getInitialViewFromSearchParams({
@@ -357,8 +362,6 @@ export default function CanvasView() {
               y: initialView.targetPoint.y,
             });
             appliedInitialView = true;
-
-            console.log("Applied initial view from search params", initialView);
           }
         }
 
@@ -381,7 +384,21 @@ export default function CanvasView() {
 
   const canvasSearchParams = useCanvasSearchParams();
   const initialCanvasSearchParamsRef = useRef(canvasSearchParams);
+  const hasAppliedInitialCanvasRef = useRef(false);
   const hasAppliedInitialViewRef = useRef(false);
+
+  useEffect(() => {
+    if (hasAppliedInitialCanvasRef.current) return;
+
+    const targetCanvasId = initialCanvasSearchParamsRef.current.canvasId;
+    if (targetCanvasId === null || targetCanvasId === canvas.id) {
+      hasAppliedInitialCanvasRef.current = true;
+      return;
+    }
+
+    hasAppliedInitialCanvasRef.current = true;
+    void setCanvas(targetCanvasId);
+  }, [canvas.id, setCanvas]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We want to show the loader when switching canvases
   useEffect(() => {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { PlacePixelSocket, Point } from "@blurple-canvas-web/types";
+import { CanvasInfo, PlacePixelSocket, Point } from "@blurple-canvas-web/types";
 import { CircularProgress, css, styled } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import config from "@/config";
 import { useCanvasContext, useSelectedColorContext } from "@/contexts";
+import { useCanvasSearchParams } from "@/hooks";
+import { CanvasSearchParams } from "@/hooks/useCanvasSearchParams";
 import { socket } from "@/socket";
 import { clamp } from "@/util";
 import { Button } from "../button";
@@ -195,8 +197,8 @@ function calculateTouchOffsetDelta(
     x: movementDelta2.x,
     y: movementDelta2.y,
   });
-  const oldMagitude = distanceBetweenPoints(oldPosition1, oldPosition2);
-  const newMagitude = distanceBetweenPoints(newPosition1, newPosition2);
+  const oldMagnitude = distanceBetweenPoints(oldPosition1, oldPosition2);
+  const newMagnitude = distanceBetweenPoints(newPosition1, newPosition2);
   const relativePosition = dividePoint(
     addPoints(newPosition1, newPosition2),
     2,
@@ -205,8 +207,57 @@ function calculateTouchOffsetDelta(
     x: movementDelta1.x + movementDelta2.x / 2,
     y: movementDelta1.y + movementDelta2.y / 2,
   };
-  const scale = newMagitude / oldMagitude;
+  const scale = newMagnitude / oldMagnitude;
   return { offsetDelta, scale, centerOffset: relativePosition };
+}
+
+function clampZoom(zoom: number, initialZoom: number) {
+  return clamp(zoom, MIN_ZOOM_FACTOR * initialZoom, MAX_ZOOM);
+}
+
+function getInitialViewFromSearchParams({
+  params,
+  canvas,
+  container,
+  initialZoom,
+}: {
+  params: CanvasSearchParams;
+  canvas: CanvasInfo;
+  container: HTMLDivElement;
+  initialZoom: number;
+}) {
+  const canvasX = params.x;
+  const canvasY = params.y;
+
+  if (canvasX === null || canvasY === null) return null;
+
+  const targetZoom =
+    params.zoom !== null ? clampZoom(params.zoom, initialZoom)
+    : params.pixelWidth !== null || params.pixelHeight !== null ?
+      clampZoom(
+        Math.min(
+          params.pixelWidth !== null ?
+            container.clientWidth / params.pixelWidth
+          : Number.POSITIVE_INFINITY,
+          params.pixelHeight !== null ?
+            container.clientHeight / params.pixelHeight
+          : Number.POSITIVE_INFINITY,
+        ),
+        initialZoom,
+      )
+    : initialZoom;
+
+  const targetPoint = {
+    x: canvasX - canvas.startCoordinates[0],
+    y: canvasY - canvas.startCoordinates[1],
+  };
+
+  const offset = {
+    x: (canvas.width / 2 - (targetPoint.x + 0.5)) * targetZoom,
+    y: (canvas.height / 2 - (targetPoint.y + 0.5)) * targetZoom,
+  };
+
+  return { targetZoom, offset, targetPoint };
 }
 
 // Arbitrary value applied to the deltaY of the wheel zoom function to make it feel right
@@ -283,15 +334,54 @@ export default function CanvasView() {
       ctx.drawImage(image, 0, 0, image.width, image.height);
       offscreenCanvasRef.current = offscreenCanvas;
       setInitialZoom(zoom);
-      setZoom(zoom);
+
+      let appliedInitialView = false;
+
+      if (!hasAppliedInitialViewRef.current) {
+        const container = containerRef.current;
+        const params = initialCanvasSearchParamsRef.current;
+
+        if (container) {
+          const initialView = getInitialViewFromSearchParams({
+            params,
+            canvas,
+            container,
+            initialZoom: zoom,
+          });
+
+          if (initialView) {
+            setZoom(initialView.targetZoom);
+            setOffset(initialView.offset);
+            setCoords({
+              x: initialView.targetPoint.x,
+              y: initialView.targetPoint.y,
+            });
+            appliedInitialView = true;
+
+            console.log("Applied initial view from search params", initialView);
+          }
+        }
+
+        // Ensure this only runs once on page load, even if params are missing/invalid.
+        hasAppliedInitialViewRef.current = true;
+      }
+
+      if (!appliedInitialView) {
+        setZoom(zoom);
+        setOffset(ORIGIN);
+      }
+
       setVelocity(ORIGIN);
-      setOffset(ORIGIN);
       setIsLoading(false);
       setIsLaunching(false);
       clearOverlay();
     },
     [canvas.id],
   );
+
+  const canvasSearchParams = useCanvasSearchParams();
+  const initialCanvasSearchParamsRef = useRef(canvasSearchParams);
+  const hasAppliedInitialViewRef = useRef(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We want to show the loader when switching canvases
   useEffect(() => {

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -396,21 +396,24 @@ export default function CanvasView() {
   const hasAppliedInitialCanvasRef = useRef(false);
   const hasAppliedInitialViewRef = useRef(false);
 
-  useEffect(() => {
-    if (hasAppliedInitialCanvasRef.current) return;
+  useEffect(
+    function switchToCanvasFromSearchParams() {
+      if (hasAppliedInitialCanvasRef.current) return;
 
-    const targetCanvasId = initialCanvasSearchParamsRef.current.canvasId;
-    if (targetCanvasId === null || targetCanvasId === canvas.id) {
+      const targetCanvasId = initialCanvasSearchParamsRef.current.canvasId;
+      if (targetCanvasId === null || targetCanvasId === canvas.id) {
+        hasAppliedInitialCanvasRef.current = true;
+        return;
+      }
+
       hasAppliedInitialCanvasRef.current = true;
-      return;
-    }
-
-    hasAppliedInitialCanvasRef.current = true;
-    void setCanvas(targetCanvasId).catch(() => {
-      // If URL canvas does not exist, keep default canvas and never apply URL pan/zoom.
-      hasAppliedInitialViewRef.current = true;
-    });
-  }, [canvas.id, setCanvas]);
+      void setCanvas(targetCanvasId).catch(() => {
+        // If URL canvas does not exist, keep default canvas and never apply URL pan/zoom.
+        hasAppliedInitialViewRef.current = true;
+      });
+    },
+    [canvas.id, setCanvas],
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We want to show the loader when switching canvases
   useEffect(() => {

--- a/packages/frontend/src/contexts/CanvasContext.tsx
+++ b/packages/frontend/src/contexts/CanvasContext.tsx
@@ -21,7 +21,6 @@ import {
 import { addPoints, tupleToPoint } from "@/components/canvas/point";
 import config from "@/config";
 import { socket } from "@/socket";
-import { SEARCH_PARAM_KEYS } from "@/util/searchParams";
 import { useSelectedColorContext } from "./SelectedColorContext";
 
 interface CanvasContextType {
@@ -95,13 +94,9 @@ export const CanvasProvider = ({
       setSelectedCoords(null);
 
       const url = new URL(window.location.href);
+      url.pathname =
+        canvasId === mainCanvasInfo.id ? "/" : `/canvas/${canvasId}`;
       url.search = "";
-      if (canvasId !== mainCanvasInfo.id) {
-        url.searchParams.set(
-          SEARCH_PARAM_KEYS.canvasId.canonical,
-          canvasId.toString(),
-        );
-      }
       router.replace(`${url.pathname}${url.search}${url.hash}`);
 
       // When we load an image, we want to make sure any pixels placed since now get included in the
@@ -112,7 +107,7 @@ export const CanvasProvider = ({
         pixelTimestamp: new Date().toISOString(),
       };
     },
-    [mainCanvasInfo.id, router, setSelectedColor],
+    [router, setSelectedColor, mainCanvasInfo.id],
   );
 
   return (

--- a/packages/frontend/src/contexts/CanvasContext.tsx
+++ b/packages/frontend/src/contexts/CanvasContext.tsx
@@ -6,6 +6,7 @@ import {
   Point,
 } from "@blurple-canvas-web/types";
 import axios from "axios";
+import { useRouter } from "next/navigation";
 import {
   createContext,
   Dispatch,
@@ -20,6 +21,7 @@ import {
 import { addPoints, tupleToPoint } from "@/components/canvas/point";
 import config from "@/config";
 import { socket } from "@/socket";
+import { SEARCH_PARAM_KEYS } from "@/util/searchParams";
 import { useSelectedColorContext } from "./SelectedColorContext";
 
 interface CanvasContextType {
@@ -63,6 +65,7 @@ export const CanvasProvider = ({
   children,
   mainCanvasInfo,
 }: CanvasProviderProps) => {
+  const router = useRouter();
   const [activeCanvas, setActiveCanvas] = useState(mainCanvasInfo);
   const [selectedCoords, setSelectedCoords] =
     useState<CanvasContextType["coords"]>(null);
@@ -91,6 +94,16 @@ export const CanvasProvider = ({
       setSelectedColor(null);
       setSelectedCoords(null);
 
+      const url = new URL(window.location.href);
+      url.search = "";
+      if (canvasId !== mainCanvasInfo.id) {
+        url.searchParams.set(
+          SEARCH_PARAM_KEYS.canvasId.canonical,
+          canvasId.toString(),
+        );
+      }
+      router.replace(`${url.pathname}${url.search}${url.hash}`);
+
       // When we load an image, we want to make sure any pixels placed since now get included in the
       // response. This is because in the time it takes for the image to load some pixels may have
       // already been placed.
@@ -99,7 +112,7 @@ export const CanvasProvider = ({
         pixelTimestamp: new Date().toISOString(),
       };
     },
-    [setSelectedColor],
+    [mainCanvasInfo.id, router, setSelectedColor],
   );
 
   return (

--- a/packages/frontend/src/contexts/CanvasContext.tsx
+++ b/packages/frontend/src/contexts/CanvasContext.tsx
@@ -9,10 +9,12 @@ import axios from "axios";
 import {
   createContext,
   Dispatch,
+  RefObject,
   SetStateAction,
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { addPoints, tupleToPoint } from "@/components/canvas/point";
@@ -21,14 +23,18 @@ import { socket } from "@/socket";
 import { useSelectedColorContext } from "./SelectedColorContext";
 
 interface CanvasContextType {
-  canvas: CanvasInfo;
-  coords: Point | null;
   adjustedCoords: Point | null;
+  canvas: CanvasInfo;
+  containerRef: RefObject<HTMLDivElement | null>;
+  coords: Point | null;
+  zoom: number;
   setCanvas: (canvasId: CanvasInfo["id"]) => void;
   setCoords: Dispatch<SetStateAction<Point | null>>;
+  setZoom: Dispatch<SetStateAction<number>>;
 }
 
 export const CanvasContext = createContext<CanvasContextType>({
+  adjustedCoords: null,
   canvas: {
     id: -1,
     name: "",
@@ -40,10 +46,12 @@ export const CanvasContext = createContext<CanvasContextType>({
     webPlacingEnabled: false,
     allColorsGlobal: false,
   },
+  containerRef: { current: null },
   coords: null,
-  adjustedCoords: null,
+  zoom: 1,
   setCoords: () => {},
   setCanvas: () => {},
+  setZoom: () => {},
 });
 
 interface CanvasProviderProps {
@@ -58,6 +66,8 @@ export const CanvasProvider = ({
   const [activeCanvas, setActiveCanvas] = useState(mainCanvasInfo);
   const [selectedCoords, setSelectedCoords] =
     useState<CanvasContextType["coords"]>(null);
+  const [zoom, setZoom] = useState(1);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   const adjustedCoords = useMemo(() => {
     if (selectedCoords) {
@@ -95,11 +105,14 @@ export const CanvasProvider = ({
   return (
     <CanvasContext.Provider
       value={{
-        coords: selectedCoords,
         adjustedCoords,
         canvas: activeCanvas,
+        containerRef: containerRef,
+        coords: selectedCoords,
+        zoom: zoom,
         setCoords: setSelectedCoords,
         setCanvas: setCanvasById,
+        setZoom: setZoom,
       }}
     >
       {children}

--- a/packages/frontend/src/contexts/CanvasContext.tsx
+++ b/packages/frontend/src/contexts/CanvasContext.tsx
@@ -28,7 +28,7 @@ interface CanvasContextType {
   containerRef: RefObject<HTMLDivElement | null>;
   coords: Point | null;
   zoom: number;
-  setCanvas: (canvasId: CanvasInfo["id"]) => void;
+  setCanvas: (canvasId: CanvasInfo["id"]) => Promise<void>;
   setCoords: Dispatch<SetStateAction<Point | null>>;
   setZoom: Dispatch<SetStateAction<number>>;
 }
@@ -50,7 +50,7 @@ export const CanvasContext = createContext<CanvasContextType>({
   coords: null,
   zoom: 1,
   setCoords: () => {},
-  setCanvas: () => {},
+  setCanvas: async () => {},
   setZoom: () => {},
 });
 

--- a/packages/frontend/src/hooks/index.ts
+++ b/packages/frontend/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./queries";
 
+export { useCanvasSearchParams } from "./useCanvasSearchParams";
 export { useScreenDimensions } from "./useScreenDimensions";

--- a/packages/frontend/src/hooks/useCanvasSearchParams.ts
+++ b/packages/frontend/src/hooks/useCanvasSearchParams.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { clamp } from "colorjs.io/src/util.js";
 import { useSearchParams } from "next/navigation";
 import { extractSearchParam } from "@/util/searchParams";
 

--- a/packages/frontend/src/hooks/useCanvasSearchParams.ts
+++ b/packages/frontend/src/hooks/useCanvasSearchParams.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { clamp } from "colorjs.io/src/util.js";
+import { useSearchParams } from "next/navigation";
+import { extractSearchParam } from "@/util/searchParams";
+
+export interface CanvasSearchParams {
+  canvasId: number | null;
+  x: number | null;
+  y: number | null;
+  zoom: number | null;
+  pixelWidth: number | null;
+  pixelHeight: number | null;
+  frameId: string | null;
+}
+
+function parseIntParam(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function parseFloatParam(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number.parseFloat(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function useCanvasSearchParams(): CanvasSearchParams {
+  const searchParams = useSearchParams();
+
+  return {
+    canvasId: parseIntParam(extractSearchParam(searchParams, "canvasId")),
+    x: parseIntParam(extractSearchParam(searchParams, "x")),
+    y: parseIntParam(extractSearchParam(searchParams, "y")),
+    zoom: parseFloatParam(extractSearchParam(searchParams, "z")),
+    pixelWidth: parseIntParam(extractSearchParam(searchParams, "pixelWidth")),
+    pixelHeight: parseIntParam(extractSearchParam(searchParams, "pixelHeight")),
+    frameId: extractSearchParam(searchParams, "frameId"),
+  };
+}

--- a/packages/frontend/src/hooks/useCanvasSearchParams.ts
+++ b/packages/frontend/src/hooks/useCanvasSearchParams.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import { extractSearchParam } from "@/util/searchParams";
 
 export interface CanvasSearchParams {
@@ -25,11 +25,20 @@ function parseFloatParam(value: string | null): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
+function parsePathParam(value: string | string[] | undefined): number | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+
+  return parseIntParam(value);
+}
+
 export function useCanvasSearchParams(): CanvasSearchParams {
+  const params = useParams<{ canvasId?: string | string[] }>();
   const searchParams = useSearchParams();
 
   return {
-    canvasId: parseIntParam(extractSearchParam(searchParams, "canvasId")),
+    canvasId:
+      parsePathParam(params.canvasId) ??
+      parseIntParam(extractSearchParam(searchParams, "canvasId")),
     x: parseIntParam(extractSearchParam(searchParams, "x")),
     y: parseIntParam(extractSearchParam(searchParams, "y")),
     zoom: parseFloatParam(extractSearchParam(searchParams, "z")),

--- a/packages/frontend/src/util/index.ts
+++ b/packages/frontend/src/util/index.ts
@@ -1,7 +1,7 @@
 import { DiscordUserProfile } from "@blurple-canvas-web/types";
 import { DateTime } from "luxon";
 
-export { default } from "./searchParams";
+export { default as createPixelUrl } from "./searchParams";
 
 /**
  * Return the value clamped so that it is within the range [min, max].

--- a/packages/frontend/src/util/index.ts
+++ b/packages/frontend/src/util/index.ts
@@ -1,6 +1,8 @@
 import { DiscordUserProfile } from "@blurple-canvas-web/types";
 import { DateTime } from "luxon";
 
+export { default } from "./searchParams";
+
 /**
  * Return the value clamped so that it is within the range [min, max].
  */

--- a/packages/frontend/src/util/searchParams.ts
+++ b/packages/frontend/src/util/searchParams.ts
@@ -1,0 +1,65 @@
+import { Point } from "@blurple-canvas-web/types";
+import config from "@/config";
+
+type SearchParamConfig = {
+  readonly canonical: string;
+  readonly aliases: readonly string[];
+};
+
+export const SEARCH_PARAM_KEYS = {
+  canvasId: { canonical: "c", aliases: ["canvas"] },
+  x: { canonical: "x", aliases: [] },
+  y: { canonical: "y", aliases: [] },
+  z: { canonical: "z", aliases: ["zoom"] },
+  pixelWidth: { canonical: "w", aliases: ["width"] },
+  pixelHeight: { canonical: "h", aliases: ["height"] },
+  frameId: { canonical: "f", aliases: ["frame"] },
+} as const satisfies Record<string, SearchParamConfig>;
+
+export default function createPixelUrl({
+  canvasId,
+  coords,
+  zoom,
+  pixelWidth,
+  pixelHeight,
+  frameId,
+}: {
+  canvasId?: number;
+  coords?: Point;
+  zoom?: number;
+  pixelWidth?: number;
+  pixelHeight?: number;
+  frameId?: string;
+}) {
+  const parameters = new Map<string, string>();
+
+  const params = [
+    { key: SEARCH_PARAM_KEYS.canvasId.canonical, value: canvasId?.toString() },
+    { key: SEARCH_PARAM_KEYS.x.canonical, value: coords?.x.toString() },
+    { key: SEARCH_PARAM_KEYS.y.canonical, value: coords?.y.toString() },
+    { key: SEARCH_PARAM_KEYS.z.canonical, value: zoom?.toFixed(3) },
+    {
+      key: SEARCH_PARAM_KEYS.pixelWidth.canonical,
+      value: pixelWidth?.toFixed(0),
+    },
+    {
+      key: SEARCH_PARAM_KEYS.pixelHeight.canonical,
+      value: pixelHeight?.toFixed(0),
+    },
+    { key: SEARCH_PARAM_KEYS.frameId.canonical, value: frameId?.toUpperCase() },
+  ];
+
+  for (const param of params) {
+    if (param.value) {
+      parameters.set(param.key, param.value);
+    }
+  }
+
+  const url = new URL(config.baseUrl);
+
+  url.search = Array.from(parameters.entries())
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+
+  return url.toString();
+}

--- a/packages/frontend/src/util/searchParams.ts
+++ b/packages/frontend/src/util/searchParams.ts
@@ -96,9 +96,9 @@ export default function createPixelUrl({
     url.pathname = `/canvas/${encodeURIComponent(canvasId)}`;
   }
 
-  parameters.forEach((value, key) => {
+  for (const [key, value] of parameters) {
     url.searchParams.set(key, value);
-  });
+  }
 
   return url.toString();
 }
@@ -109,12 +109,10 @@ export function extractSearchParam(
 ): string | null {
   if (!searchParams) return null;
 
-  for (const variant of getSearchParamVariants(key)) {
+  const variantUsed = getSearchParamVariants(key).find((variant) => {
     const value = searchParams.get(variant);
-    if (value !== null && value.length > 0) {
-      return value;
-    }
-  }
+    return value !== null && value.length > 0;
+  });
 
-  return null;
+  return variantUsed ? searchParams.get(variantUsed) : null;
 }

--- a/packages/frontend/src/util/searchParams.ts
+++ b/packages/frontend/src/util/searchParams.ts
@@ -16,6 +16,19 @@ export const SEARCH_PARAM_KEYS = {
   frameId: { canonical: "f", aliases: ["frame"] },
 } as const satisfies Record<string, SearchParamConfig>;
 
+export type ParamKey = keyof typeof SEARCH_PARAM_KEYS;
+
+type ParamVariant<K extends ParamKey> =
+  | (typeof SEARCH_PARAM_KEYS)[K]["canonical"]
+  | (typeof SEARCH_PARAM_KEYS)[K]["aliases"][number];
+
+function getSearchParamVariants<K extends ParamKey>(
+  key: K,
+): readonly ParamVariant<K>[] {
+  const config = SEARCH_PARAM_KEYS[key];
+  return [config.canonical, ...config.aliases];
+}
+
 export default function createPixelUrl({
   canvasId,
   coords,
@@ -62,4 +75,18 @@ export default function createPixelUrl({
     .join("&");
 
   return url.toString();
+}
+
+export function extractSearchParam(
+  searchParams: URLSearchParams | null,
+  key: ParamKey,
+): string | null {
+  if (!searchParams) return null;
+
+  return (
+    getSearchParamVariants(key)
+      .map((variant) => searchParams.get(variant))
+      .find((value): value is string => value !== null && value.length > 0) ??
+    null
+  );
 }

--- a/packages/frontend/src/util/searchParams.ts
+++ b/packages/frontend/src/util/searchParams.ts
@@ -47,7 +47,6 @@ export default function createPixelUrl({
   const parameters = new Map<string, string>();
 
   const params = [
-    { key: SEARCH_PARAM_KEYS.canvasId.canonical, value: canvasId?.toString() },
     { key: SEARCH_PARAM_KEYS.x.canonical, value: coords?.x.toString() },
     { key: SEARCH_PARAM_KEYS.y.canonical, value: coords?.y.toString() },
     { key: SEARCH_PARAM_KEYS.z.canonical, value: zoom?.toFixed(3) },
@@ -69,6 +68,10 @@ export default function createPixelUrl({
   }
 
   const url = new URL(config.baseUrl);
+
+  if (canvasId !== undefined) {
+    url.pathname = `/canvas/${canvasId}`;
+  }
 
   url.search = Array.from(parameters.entries())
     .map(([key, value]) => `${key}=${value}`)

--- a/packages/frontend/src/util/searchParams.ts
+++ b/packages/frontend/src/util/searchParams.ts
@@ -1,10 +1,10 @@
 import { Point } from "@blurple-canvas-web/types";
 import config from "@/config";
 
-type SearchParamConfig = {
+export interface SearchParamConfig {
   readonly canonical: string;
   readonly aliases: readonly string[];
-};
+}
 
 export const SEARCH_PARAM_KEYS = {
   canvasId: { canonical: "c", aliases: ["canvas"] },
@@ -22,6 +22,15 @@ type ParamVariant<K extends ParamKey> =
   | (typeof SEARCH_PARAM_KEYS)[K]["canonical"]
   | (typeof SEARCH_PARAM_KEYS)[K]["aliases"][number];
 
+export interface CreatePixelUrlOptions {
+  canvasId?: number;
+  coords?: Point;
+  zoom?: number;
+  pixelWidth?: number;
+  pixelHeight?: number;
+  frameId?: string;
+}
+
 function getSearchParamVariants<K extends ParamKey>(
   key: K,
 ): readonly ParamVariant<K>[] {
@@ -36,17 +45,13 @@ export default function createPixelUrl({
   pixelWidth,
   pixelHeight,
   frameId,
-}: {
-  canvasId?: number;
-  coords?: Point;
-  zoom?: number;
-  pixelWidth?: number;
-  pixelHeight?: number;
-  frameId?: string;
-}) {
-  const parameters = new Map<string, string>();
+}: CreatePixelUrlOptions) {
+  const parameters = new Map<ParamVariant<ParamKey>, string>();
 
-  const params = [
+  const params: readonly {
+    key: ParamVariant<ParamKey>;
+    value: string | undefined;
+  }[] = [
     { key: SEARCH_PARAM_KEYS.x.canonical, value: coords?.x.toString() },
     { key: SEARCH_PARAM_KEYS.y.canonical, value: coords?.y.toString() },
     { key: SEARCH_PARAM_KEYS.z.canonical, value: zoom?.toFixed(3) },

--- a/packages/frontend/src/util/searchParams.ts
+++ b/packages/frontend/src/util/searchParams.ts
@@ -38,8 +38,7 @@ function getSearchParamVariants<K extends ParamKey>(
   return [config.canonical, ...config.aliases];
 }
 
-export default function createPixelUrl({
-  canvasId,
+function initParameters({
   coords,
   zoom,
   pixelWidth,
@@ -72,15 +71,34 @@ export default function createPixelUrl({
     }
   }
 
+  return parameters;
+}
+
+export default function createPixelUrl({
+  canvasId,
+  coords,
+  zoom,
+  pixelWidth,
+  pixelHeight,
+  frameId,
+}: CreatePixelUrlOptions) {
+  const parameters = initParameters({
+    coords,
+    zoom,
+    pixelWidth,
+    pixelHeight,
+    frameId,
+  });
+
   const url = new URL(config.baseUrl);
 
   if (canvasId !== undefined) {
-    url.pathname = `/canvas/${canvasId}`;
+    url.pathname = `/canvas/${encodeURIComponent(canvasId)}`;
   }
 
-  url.search = Array.from(parameters.entries())
-    .map(([key, value]) => `${key}=${value}`)
-    .join("&");
+  parameters.forEach((value, key) => {
+    url.searchParams.set(key, value);
+  });
 
   return url.toString();
 }
@@ -91,10 +109,12 @@ export function extractSearchParam(
 ): string | null {
   if (!searchParams) return null;
 
-  return (
-    getSearchParamVariants(key)
-      .map((variant) => searchParams.get(variant))
-      .find((value): value is string => value !== null && value.length > 0) ??
-    null
-  );
+  for (const variant of getSearchParamVariants(key)) {
+    const value = searchParams.get(variant);
+    if (value !== null && value.length > 0) {
+      return value;
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
- When loading URL with search params, canvas loads at the specific coordinates and zoom
- Button to create URL for the currently selected pixel + current zoom
- Canvas persists across reloads via being set as search param

Redoing https://github.com/project-blurple/Canvas-Web/pull/229