### PR TITLE
feat: env toggle hide bot commands

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -2,3 +2,5 @@ BASE_URL=
 NEXT_PUBLIC_API_URL=
 
 DISCORD_SERVER_INVITE=https://discord.gg/blurple
+
+SHOW_BOT_COMMANDS=true

--- a/packages/frontend/src/components/action-panel/tabs/BotCommandCard.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/BotCommandCard.tsx
@@ -1,5 +1,6 @@
 import { styled } from "@mui/material";
 import { Copy as CopyIcon } from "lucide-react";
+import config from "@/config";
 import { useCanvasContext, useSelectedColorContext } from "@/contexts";
 
 const Wrapper = styled("div")`
@@ -42,6 +43,8 @@ const StyledCopyIcon = styled(CopyIcon)`
 export default function BotCommandCard() {
   const { adjustedCoords: coordinates } = useCanvasContext();
   const { color } = useSelectedColorContext();
+
+  if (config.showBotCommands === false) return null;
 
   if (!coordinates || !color) return null;
 

--- a/packages/frontend/src/config/index.ts
+++ b/packages/frontend/src/config/index.ts
@@ -5,6 +5,7 @@ const config = {
   port: process.env.PORT || 3000,
   discordServerInvite:
     process.env.DISCORD_SERVER_INVITE || "https://projectblurple.com",
+  showBotCommands: process.env.SHOW_BOT_COMMANDS === "true",
 } as const;
 
 export default config;


### PR DESCRIPTION
A small toggle to hide bot commands, as set in env. Useful for if we're not running the bot in parallel.

(bot commands ie the copyable `/paste x:...` in the place tab)

This doesn't disable the socket, however