### PR TITLE
fix: Invite mismatch causing hydration error

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,4 +1,4 @@
 BASE_URL=
 NEXT_PUBLIC_API_URL=
 
-DISCORD_SERVER_INVITE=https://discord.gg/blurple
+NEXT_PUBLIC_DISCORD_SERVER_INVITE=https://discord.gg/qEmKyCf

--- a/packages/frontend/src/config/index.ts
+++ b/packages/frontend/src/config/index.ts
@@ -4,7 +4,8 @@ const config = {
     process.env.BASE_URL || `http://localhost:${process.env.PORT || 3000}`,
   port: process.env.PORT || 3000,
   discordServerInvite:
-    process.env.DISCORD_SERVER_INVITE || "https://projectblurple.com",
+    process.env.NEXT_PUBLIC_DISCORD_SERVER_INVITE ||
+    "https://projectblurple.com",
 } as const;
 
 export default config;

--- a/packages/frontend/src/config/processEnv.d.ts
+++ b/packages/frontend/src/config/processEnv.d.ts
@@ -4,5 +4,6 @@
 declare namespace NodeJS {
   export interface ProcessEnv {
     NEXT_PUBLIC_API_URL?: string;
+    NEXT_PUBLIC_DISCORD_SERVER_INVITE?: string;
   }
 }


### PR DESCRIPTION
The Discord server invite is set in the front-end env, but due to it not loading immediately, it causes a hydration error if it does not match the default https://projectblurple.com