### PR TITLE
refactor(frontend): retire dynamically coloured button `filter` hack 

### DIFF
--- a/packages/frontend/src/components/button/DynamicButton.tsx
+++ b/packages/frontend/src/components/button/DynamicButton.tsx
@@ -17,7 +17,6 @@ const StyledButton = styled(ButtonBase, {
     background-color: var(--dynamic-bg-color);
 
     :hover,
-    :focus,
     :focus-visible {
       ${({ backgroundColorStr }) =>
         backgroundColorStr &&
@@ -38,21 +37,28 @@ const StyledButton = styled(ButtonBase, {
 const DynamicButtonContent = styled("span")`
   display: block flex;
   gap: 0.25rem;
-  opacity: 95%;
-  transition:
-    color var(--transition-duration-fast) ease,
-    filter var(--transition-duration-fast) ease,
-    font-weight var(--transition-duration-fast) ease;
+  transition-duration: var(--transition-duration-fast);
+  transition-property: color, filter, font-weight;
+  transition-timing-function: ease;
 
-  /*
-   * Ensure contrast of button label against background. The color property
-   * should match that of the background it sits against.
-   *
-   * From https://robinrendle.com/the-cascade/015-context-aware-colors
-   */
-  color: var(--dynamic-bg-color);
-  filter: invert(1) grayscale(1) brightness(1.3) contrast(9000);
-  mix-blend-mode: luminosity;
+  @supports (color: color-mix(in oklab, black, black)) {
+    color: color-mix(
+      in oklab,
+      contrast-color(var(--dynamic-bg-color)) 94%,
+      var(--dynamic-bg-color)
+    );
+  }
+
+  @supports not (color: color-mix(in oklab, black, black)) {
+    /*
+     * Ensure contrast of button label against background. The color property
+     * should match that of the background it sits against.
+     * From https://robinrendle.com/the-cascade/015-context-aware-colors
+     */
+    color: var(--dynamic-bg-color);
+    filter: invert(1) grayscale(1) brightness(1.3) contrast(9000);
+    mix-blend-mode: luminosity;
+  }
 `;
 
 interface DynamicButtonProps {
@@ -69,10 +75,8 @@ export default function DynamicButton({
   onAction,
   ...props
 }: DynamicButtonProps) {
-  const rgba = color?.rgba;
-  const rgb = rgba?.slice(0, 3).join(" ");
-
-  const backgroundColorStr = color ? `rgb(${rgb})` : undefined;
+  const rgb = color?.rgba?.slice(0, 3).join(" ");
+  const backgroundColorStr = rgb ? `rgb(${rgb})` : undefined;
 
   const clickHandler = onAction;
   const keyUpHandler = (event: React.KeyboardEvent) => {
@@ -94,13 +98,12 @@ export default function DynamicButton({
 }
 
 export function DynamicAnchorButton({
-  children,
   href,
   ...props
 }: DynamicButtonProps & { href: string }) {
   return (
     <StyledAnchor href={href} target="_blank" rel="noreferrer">
-      <DynamicButton {...props}>{children}</DynamicButton>
+      <DynamicButton {...props} />
     </StyledAnchor>
   );
 }


### PR DESCRIPTION
What we were trying to do is precisely what [`contrast-color()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/contrast-color) is good at (and arguably _for_`)

Keeping the older hack (which I still like) around because Chromium browser support isn’t quite there yet (though not far off!)