### PR TITLE
refactor: split CanvasContext out to CanvasViewContext

### DIFF
--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import type { Metadata, Viewport } from "next";
 
 import config from "@/config";
 import {
+  CanvasViewProvider,
   QueryClientProvider,
   SelectedColorProvider,
   SelectedFrameProvider,
@@ -80,28 +81,36 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  return (
+    <html lang="en">
+      <body>
+        <LayoutProviders>{children}</LayoutProviders>
+      </body>
+    </html>
+  );
+}
+
+async function LayoutProviders({ children }: { children: React.ReactNode }) {
   const [profile, canvasInfo] = await Promise.all([
     getServerSideProfile(),
     getServerSideCanvasInfo(),
   ]);
 
   return (
-    <html lang="en">
-      <body>
-        <AppRouterCacheProvider>
-          <QueryClientProvider>
-            <AuthProvider profile={profile}>
-              <SelectedColorProvider>
-                <SelectedFrameProvider>
-                  <CanvasProvider mainCanvasInfo={canvasInfo}>
-                    <ThemeProvider theme={Theme}>{children}</ThemeProvider>
-                  </CanvasProvider>
-                </SelectedFrameProvider>
-              </SelectedColorProvider>
-            </AuthProvider>
-          </QueryClientProvider>
-        </AppRouterCacheProvider>
-      </body>
-    </html>
+    <AppRouterCacheProvider>
+      <QueryClientProvider>
+        <AuthProvider profile={profile}>
+          <SelectedColorProvider>
+            <SelectedFrameProvider>
+              <CanvasProvider mainCanvasInfo={canvasInfo}>
+                <CanvasViewProvider>
+                  <ThemeProvider theme={Theme}>{children}</ThemeProvider>
+                </CanvasViewProvider>
+              </CanvasProvider>
+            </SelectedFrameProvider>
+          </SelectedColorProvider>
+        </AuthProvider>
+      </QueryClientProvider>
+    </AppRouterCacheProvider>
   );
 }

--- a/packages/frontend/src/components/action-panel/ActionPanel.tsx
+++ b/packages/frontend/src/components/action-panel/ActionPanel.tsx
@@ -3,7 +3,11 @@
 import { PaletteColor } from "@blurple-canvas-web/types";
 import { css, styled } from "@mui/material";
 import { useState } from "react";
-import { useCanvasContext, useSelectedColorContext } from "@/contexts";
+import {
+  useCanvasContext,
+  useCanvasViewContext,
+  useSelectedColorContext,
+} from "@/contexts";
 import { PixelInfoTab, PlacePixelTab } from "./tabs";
 import FramesTab from "./tabs/FramesTab";
 
@@ -132,7 +136,8 @@ export default function ActionPanel() {
   const [tempColor, setTempColor] = useState<PaletteColor | null>(null);
 
   const { color, setColor } = useSelectedColorContext();
-  const { canvas, setIsReticleVisible } = useCanvasContext();
+  const { canvas } = useCanvasContext();
+  const { setIsReticleVisible } = useCanvasViewContext();
 
   const onSwitchTab = (newTab: TABS) => {
     // switching tabs

--- a/packages/frontend/src/components/action-panel/tabs/BotCommandCard.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/BotCommandCard.tsx
@@ -2,7 +2,7 @@ import { styled } from "@mui/material";
 import { Copy as CopyIcon } from "lucide-react";
 import VisuallyHidden from "@/components/VisuallyHidden";
 import config from "@/config";
-import { useCanvasContext, useSelectedColorContext } from "@/contexts";
+import { useCanvasViewContext, useSelectedColorContext } from "@/contexts";
 
 const Wrapper = styled("div")`
   align-items: center;
@@ -58,7 +58,7 @@ export default function BotCommandCard({ command }: { command: string }) {
 }
 
 export function BotPlaceCommandCard() {
-  const { adjustedCoords: coordinates } = useCanvasContext();
+  const { adjustedCoords: coordinates } = useCanvasViewContext();
   const { color } = useSelectedColorContext();
 
   if (!(coordinates && color)) return null;

--- a/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
@@ -2,7 +2,7 @@ import { PixelHistoryRecord } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material";
 import { useState } from "react";
 import { DynamicButton } from "@/components/button";
-import { useCanvasContext } from "@/contexts";
+import { useCanvasContext, useCanvasViewContext } from "@/contexts";
 import { usePixelHistory } from "@/hooks";
 import { createPixelUrl } from "@/util";
 import { Heading } from "../ActionPanel";
@@ -76,8 +76,8 @@ export default function PixelInfoTab({
   active = false,
   canvasId,
 }: PixelInfoTabProps) {
-  const { adjustedCoords, canvas, containerRef, coords, zoom } =
-    useCanvasContext();
+  const { canvas } = useCanvasContext();
+  const { adjustedCoords, containerRef, coords, zoom } = useCanvasViewContext();
   const { data, isLoading } = usePixelHistory(canvasId, coords);
 
   const pixelHistory = data?.pixelHistory ?? [];

--- a/packages/frontend/src/components/button/PlacePixelButton.tsx
+++ b/packages/frontend/src/components/button/PlacePixelButton.tsx
@@ -7,6 +7,7 @@ import config from "@/config";
 import {
   useAuthContext,
   useCanvasContext,
+  useCanvasViewContext,
   useSelectedColorContext,
 } from "@/contexts";
 import { Button } from "./Button";
@@ -21,7 +22,8 @@ interface PlacePixelButtonProps {
 }
 
 export default function PlacePixelButton({ isVerbose }: PlacePixelButtonProps) {
-  const { canvas, coords, adjustedCoords, setCoords } = useCanvasContext();
+  const { canvas } = useCanvasContext();
+  const { coords, adjustedCoords, setCoords } = useCanvasViewContext();
   const { color } = useSelectedColorContext();
   const isSelected = adjustedCoords && color;
   const [timeLeft, setTimeLeft] = useState(0);

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import config from "@/config";
 import {
   useCanvasContext,
+  useCanvasViewContext,
   useSelectedColorContext,
   useSelectedFrameContext,
 } from "@/contexts";
@@ -369,16 +370,9 @@ export default function CanvasView() {
 
   const { color } = useSelectedColorContext();
   const [frame, setFrame] = useSelectedFrameContext();
-  const {
-    canvas,
-    containerRef,
-    coords,
-    isReticleVisible,
-    zoom,
-    setCanvas,
-    setCoords,
-    setZoom,
-  } = useCanvasContext();
+  const { canvas, setCanvas } = useCanvasContext();
+  const { containerRef, coords, isReticleVisible, zoom, setCoords, setZoom } =
+    useCanvasViewContext();
   const sourceImage = useCanvasImage(canvas.id);
 
   const [isLoading, setIsLoading] = useState(true);

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -1008,7 +1008,7 @@ export default function CanvasView() {
             />
           )}
           <Reticle
-            src="./images/reticle.png"
+            src="/images/reticle.png"
             alt="Reticle"
             className="reticle"
             style={{

--- a/packages/frontend/src/contexts/CanvasContext.tsx
+++ b/packages/frontend/src/contexts/CanvasContext.tsx
@@ -1,44 +1,21 @@
 "use client";
 
-import {
-  CanvasInfo,
-  CanvasInfoRequest,
-  Point,
-} from "@blurple-canvas-web/types";
+import { CanvasInfo, CanvasInfoRequest } from "@blurple-canvas-web/types";
 import axios from "axios";
 import { useRouter } from "next/navigation";
-import {
-  createContext,
-  Dispatch,
-  RefObject,
-  SetStateAction,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { addPoints, tupleToPoint } from "@/components/canvas/point";
+import { createContext, useCallback, useContext, useState } from "react";
 import config from "@/config";
 import { socket } from "@/socket";
+import { useCanvasViewContext } from "./CanvasViewContext";
 import { useSelectedColorContext } from "./SelectedColorContext";
 import { useSelectedFrameContext } from "./SelectedFrameContext";
 
 interface CanvasContextType {
-  adjustedCoords: Point | null;
   canvas: CanvasInfo;
-  containerRef: RefObject<HTMLDivElement | null>;
-  coords: Point | null;
-  isReticleVisible: boolean;
-  zoom: number;
   setCanvas: (canvasId: CanvasInfo["id"]) => Promise<void>;
-  setCoords: Dispatch<SetStateAction<Point | null>>;
-  setIsReticleVisible: Dispatch<SetStateAction<boolean>>;
-  setZoom: Dispatch<SetStateAction<number>>;
 }
 
 export const CanvasContext = createContext<CanvasContextType>({
-  adjustedCoords: null,
   canvas: {
     id: -1,
     name: "",
@@ -50,14 +27,7 @@ export const CanvasContext = createContext<CanvasContextType>({
     webPlacingEnabled: false,
     allColorsGlobal: false,
   },
-  containerRef: { current: null },
-  coords: null,
-  isReticleVisible: false,
-  zoom: 1,
-  setCoords: () => {},
   setCanvas: async () => {},
-  setZoom: () => {},
-  setIsReticleVisible: () => {},
 });
 
 interface CanvasProviderProps {
@@ -71,26 +41,10 @@ export const CanvasProvider = ({
 }: CanvasProviderProps) => {
   const router = useRouter();
   const [activeCanvas, setActiveCanvas] = useState(mainCanvasInfo);
-  const [selectedCoords, setSelectedCoords] =
-    useState<CanvasContextType["coords"]>(null);
-  const [isReticleVisible, setIsReticleVisible] =
-    useState<CanvasContextType["isReticleVisible"]>(true);
-  const [zoom, setZoom] = useState(1);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { setCoords } = useCanvasViewContext();
 
-  const adjustedCoords = useMemo(() => {
-    if (selectedCoords) {
-      return addPoints(
-        selectedCoords,
-        tupleToPoint(activeCanvas.startCoordinates),
-      );
-    }
-
-    return null;
-  }, [activeCanvas.startCoordinates, selectedCoords]);
-
-  const { setColor: setSelectedColor } = useSelectedColorContext();
-  const [, setSelectedFrame] = useSelectedFrameContext();
+  const { setColor } = useSelectedColorContext();
+  const [, setFrame] = useSelectedFrameContext();
 
   const setCanvasById = useCallback<CanvasContextType["setCanvas"]>(
     async (canvasId: CanvasInfo["id"]) => {
@@ -98,9 +52,9 @@ export const CanvasProvider = ({
         `${config.apiUrl}/api/v1/canvas/${encodeURIComponent(canvasId)}/info`,
       );
       setActiveCanvas(response.data);
-      setSelectedColor(null);
-      setSelectedCoords(null);
-      setSelectedFrame(null);
+      setColor(null);
+      setCoords(null);
+      setFrame(null);
 
       const url = new URL(window.location.href);
       url.pathname =
@@ -116,22 +70,14 @@ export const CanvasProvider = ({
         pixelTimestamp: new Date().toISOString(),
       };
     },
-    [router, setSelectedColor, setSelectedFrame, mainCanvasInfo.id],
+    [router, setColor, setFrame, setCoords, mainCanvasInfo.id],
   );
 
   return (
     <CanvasContext.Provider
       value={{
-        adjustedCoords,
         canvas: activeCanvas,
-        isReticleVisible: isReticleVisible && selectedCoords !== null,
-        containerRef: containerRef,
-        coords: selectedCoords,
-        zoom: zoom,
-        setCoords: setSelectedCoords,
         setCanvas: setCanvasById,
-        setIsReticleVisible: setIsReticleVisible,
-        setZoom: setZoom,
       }}
     >
       {children}

--- a/packages/frontend/src/contexts/CanvasViewContext.tsx
+++ b/packages/frontend/src/contexts/CanvasViewContext.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Point } from "@blurple-canvas-web/types";
+import {
+  createContext,
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { addPoints, tupleToPoint } from "@/components/canvas/point";
+import { useCanvasContext } from "./CanvasContext";
+
+interface CanvasViewContextType {
+  adjustedCoords: Point | null;
+  containerRef: RefObject<HTMLDivElement | null>;
+  coords: Point | null;
+  isReticleVisible: boolean;
+  zoom: number;
+  setCoords: Dispatch<SetStateAction<Point | null>>;
+  setIsReticleVisible: Dispatch<SetStateAction<boolean>>;
+  setZoom: Dispatch<SetStateAction<number>>;
+}
+
+export const CanvasViewContext = createContext<CanvasViewContextType>({
+  adjustedCoords: null,
+  containerRef: { current: null },
+  coords: null,
+  isReticleVisible: false,
+  zoom: 1,
+  setCoords: () => {},
+  setZoom: () => {},
+  setIsReticleVisible: () => {},
+});
+
+interface CanvasViewProviderProps {
+  children: React.ReactNode;
+}
+
+export const CanvasViewProvider = ({ children }: CanvasViewProviderProps) => {
+  const { canvas } = useCanvasContext();
+  const [selectedCoords, setSelectedCoords] =
+    useState<CanvasViewContextType["coords"]>(null);
+  const [isReticleVisible, setIsReticleVisible] =
+    useState<CanvasViewContextType["isReticleVisible"]>(true);
+  const [zoom, setZoom] = useState(1);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const adjustedCoords = useMemo(() => {
+    if (selectedCoords) {
+      return addPoints(selectedCoords, tupleToPoint(canvas.startCoordinates));
+    }
+
+    return null;
+  }, [canvas.startCoordinates, selectedCoords]);
+
+  return (
+    <CanvasViewContext.Provider
+      value={{
+        adjustedCoords,
+        isReticleVisible: isReticleVisible && selectedCoords !== null,
+        containerRef: containerRef,
+        coords: selectedCoords,
+        zoom: zoom,
+        setCoords: setSelectedCoords,
+        setIsReticleVisible: setIsReticleVisible,
+        setZoom: setZoom,
+      }}
+    >
+      {children}
+    </CanvasViewContext.Provider>
+  );
+};
+
+export const useCanvasViewContext = () => useContext(CanvasViewContext);

--- a/packages/frontend/src/contexts/index.ts
+++ b/packages/frontend/src/contexts/index.ts
@@ -1,5 +1,6 @@
 export { AuthProvider, useAuthContext } from "./AuthProvider";
 export { CanvasProvider, useCanvasContext } from "./CanvasContext";
+export { CanvasViewProvider, useCanvasViewContext } from "./CanvasViewContext";
 export { QueryClientProvider } from "./QueryClientProvider";
 export {
   SelectedColorProvider,


### PR DESCRIPTION
`CanvasContext` was getting rather bloated, so this PR splits out all the CanvasView-related states into `CanvasViewContext`

also a small reticle fix