### PR TITLE
fix: zoom drift 🏎️

### DIFF
--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -717,6 +717,7 @@ export default function CanvasView() {
      * in on a specific pixel, we need to offset the image so that the pixel we're zooming in on
      * stays in the same place on the screen after the zoom.
      */
+    const container = containerRef.current;
     const handleWheel = (event: WheelEvent): void => {
       event.preventDefault();
       // Ensures that the handler can be added to a parent element but only operates on the canvas image wrapper.
@@ -739,12 +740,11 @@ export default function CanvasView() {
       handleZoom(scale, pointerPosition, elem);
     };
 
-    containerRef.current?.addEventListener("wheel", handleWheel, {
+    container?.addEventListener("wheel", handleWheel, {
       passive: false,
     });
 
-    return () =>
-      containerRef.current?.removeEventListener("wheel", handleWheel);
+    return () => container?.removeEventListener("wheel", handleWheel);
   }, [handleZoom, containerRef]);
 
   /********************************


### PR DESCRIPTION
Stupid stupid code, I wonder who wrote this code. Oh wait, it was me.

Issue was caused in the previous version by the most recent `containerRef.current` being in the `useEffect`, so when the cleanup ran it would run on `undefined // containerRef.current` sometimes, causing the component to have 2 event handlers. Fixed by capturing the current container as a const in the `useEffect`.

Resolves #427.