### PR TITLE
chore: remove `lint-staged` from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -14,5 +14,3 @@ if [ $(git branch --show-current) = main ]; then
 
   exit 1
 fi
-
-pnpm lint-staged


### PR DESCRIPTION
I’ll probably remove **husky** entirely eventually—save us the extra dependency—and move the don’t-commit-to-main thing to an opt-in `pre-commit` using Git’s native hooks

Just keeping this PR small for now