### PR TITLE
feat(frontend): leaderboard facelift

### DIFF
--- a/packages/frontend/src/app/leaderboard/Leaderboard.tsx
+++ b/packages/frontend/src/app/leaderboard/Leaderboard.tsx
@@ -19,17 +19,13 @@ const TitleBlock = styled("div")`
   text-align: center;
 `;
 
-const Table = styled("table")`
-  font-size: min(4svw, 1.75rem);
+const List = styled("ol")`
+  display: grid;
+  font-size: 1.2rem;
   font-variant-numeric: tabular-nums;
   font-weight: 500;
-  inline-size: min(40rem, 100%);
-
-  th,
-  td {
-    --cell-padding: min(1.5svw, 1rem);
-    padding: var(--cell-padding);
-  }
+  grid-template-columns: auto 1fr auto;
+  inline-size: min(36rem, 100%);
 `;
 
 const NoContentsMessage = styled("p")`
@@ -65,27 +61,20 @@ export default function Leaderboard() {
         <h1>Leaderboard</h1>
         <h2>{canvas.name}</h2>
       </TitleBlock>
-      <Table>
-        <thead hidden>
-          <tr>
-            <th>Rank</th>
-            <th>User</th>
-            <th>Pixels placed</th>
-          </tr>
-        </thead>
-        <tbody>
-          {isLeaderboardLoading ?
-            Array.from({ length: size }, (_, index) => (
-              <LeaderboardRowSkeleton key={index.toString()} />
-            ))
-          : isLeaderboardEmpty ?
-            <NoContentsMessage>No leaderboard found</NoContentsMessage>
-          : leaderboard.map((entry) => (
-              <LeaderboardRow key={entry.userId} entry={entry} />
-            ))
-          }
-        </tbody>
-      </Table>
+
+      {/** biome-ignore lint/a11y/noRedundantRoles: <explanation> */}
+      <List start={leaderboard?.[0]?.rank} role="list">
+        {isLeaderboardLoading ?
+          Array.from({ length: 10 }, (_, index) => (
+            <LeaderboardRowSkeleton key={index.toString()} />
+          ))
+        : isLeaderboardEmpty ?
+          <NoContentsMessage>No leaderboard found</NoContentsMessage>
+        : leaderboard.map((entry) => (
+            <LeaderboardRow key={entry.userId} entry={entry} />
+          ))
+        }
+      </List>
       <Pagination
         page={page}
         siblingCount={0}

--- a/packages/frontend/src/app/leaderboard/Leaderboard.tsx
+++ b/packages/frontend/src/app/leaderboard/Leaderboard.tsx
@@ -44,6 +44,10 @@ const NoContentsMessage = styled("p")`
   text-align: center;
 `;
 
+const StyledPaginationItem = styled(PaginationItem)`
+  font-variant-numeric: tabular-nums;
+`;
+
 const customIconSlots = {
   first: ChevronFirst,
   previous: ChevronLeft,
@@ -101,7 +105,7 @@ export default function Leaderboard() {
         onChange={(_, value) => setPage(value)}
         page={page}
         renderItem={(item) => (
-          <PaginationItem slots={customIconSlots} {...item} />
+          <StyledPaginationItem slots={customIconSlots} {...item} />
         )}
         shape="rounded"
         showFirstButton

--- a/packages/frontend/src/app/leaderboard/Leaderboard.tsx
+++ b/packages/frontend/src/app/leaderboard/Leaderboard.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { Pagination, PaginationItem, styled } from "@mui/material";
-import { useEffect, useState } from "react";
 import { useCanvasContext } from "@/contexts";
 import { useLeaderboard } from "@/hooks/queries/useLeaderboard";
+import { styled } from "@mui/material";
+import Pagination from "@mui/material/Pagination";
+import PaginationItem from "@mui/material/PaginationItem";
+import { useEffect, useState } from "react";
 import LeaderboardRow, { LeaderboardRowSkeleton } from "./LeaderboardRow";
 
 const Wrapper = styled("div")`

--- a/packages/frontend/src/app/leaderboard/Leaderboard.tsx
+++ b/packages/frontend/src/app/leaderboard/Leaderboard.tsx
@@ -30,7 +30,6 @@ const TitleBlock = styled("div")`
 const List = styled("ol")`
   display: grid;
   font-size: 1.2rem;
-  font-variant-numeric: tabular-nums;
   font-weight: 500;
   grid-template-columns: auto 1fr auto;
   inline-size: min(36rem, 100%);

--- a/packages/frontend/src/app/leaderboard/Leaderboard.tsx
+++ b/packages/frontend/src/app/leaderboard/Leaderboard.tsx
@@ -4,8 +4,7 @@ import { useCanvasContext } from "@/contexts";
 import { useLeaderboard } from "@/hooks/queries/useLeaderboard";
 import { styled } from "@mui/material";
 import Pagination from "@mui/material/Pagination";
-import PaginationItem from "@mui/material/PaginationItem";
-import { useEffect, useState } from "react";
+import { useId, useState } from "react";
 import LeaderboardRow, { LeaderboardRowSkeleton } from "./LeaderboardRow";
 
 const Wrapper = styled("div")`
@@ -40,22 +39,21 @@ const NoContentsMessage = styled("p")`
 
 export default function Leaderboard() {
   const { canvas } = useCanvasContext();
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(1); // TODO: Use URL for this state
+
   const {
-    data: { total, page: currentPage, size, entries: leaderboard } = {
-      total: undefined,
-      page: page,
-      size: 10,
-      entries: [],
-    },
-    isLoading: isLeaderboardLoading,
+    data: { total, page: currentPage, size = 10, entries } = {},
+    isFetching: isLeaderboardFetching,
   } = useLeaderboard(canvas.id, page);
+  const isLeaderboardEmpty = entries?.length === 0;
 
-  useEffect(() => {
-    if (canvas.id) setPage(1);
-  }, [canvas.id]);
+  const [prevCanvasId, setPrevCanvasId] = useState(canvas.id);
+  if (prevCanvasId !== canvas.id) {
+    setPage(1);
+    setPrevCanvasId(canvas.id);
+  }
 
-  const isLeaderboardEmpty = leaderboard.length === 0;
+  const listId = useId();
 
   return (
     <Wrapper>
@@ -65,42 +63,32 @@ export default function Leaderboard() {
       </TitleBlock>
 
       {/** biome-ignore lint/a11y/noRedundantRoles: <explanation> */}
-      <List start={leaderboard?.[0]?.rank} role="list">
-        {isLeaderboardLoading ?
+      <List
+        aria-busy={isLeaderboardFetching}
+        id={listId}
+        role="list"
+        start={entries?.[0]?.rank}
+      >
+        {isLeaderboardFetching ?
           Array.from({ length: 10 }, (_, index) => (
             <LeaderboardRowSkeleton key={index.toString()} />
           ))
         : isLeaderboardEmpty ?
           <NoContentsMessage>No leaderboard found</NoContentsMessage>
-        : leaderboard.map((entry) => (
+        : entries?.map((entry) => (
             <LeaderboardRow key={entry.userId} entry={entry} />
           ))
         }
       </List>
       <Pagination
+        aria-controls={listId}
+        color="primary"
+        count={total ? Math.ceil(total / size) : currentPage}
+        onChange={(_, value) => setPage(value)}
         page={page}
-        siblingCount={0}
-        boundaryCount={0}
+        shape="rounded"
         showFirstButton
         showLastButton
-        onChange={(_, value) => setPage(value)}
-        count={total ? Math.ceil(total / size) : currentPage}
-        color="primary"
-        size="large"
-        renderItem={(item) => {
-          switch (item.type) {
-            case "start-ellipsis":
-            case "end-ellipsis":
-              return null;
-            case "page":
-              if (item.page !== currentPage) return null;
-          }
-
-          return <PaginationItem {...item} />;
-        }}
-        sx={{
-          display: total === 0 ? "none" : "inherit",
-        }}
       />
     </Wrapper>
   );

--- a/packages/frontend/src/app/leaderboard/Leaderboard.tsx
+++ b/packages/frontend/src/app/leaderboard/Leaderboard.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { useCanvasContext } from "@/contexts";
-import { useLeaderboard } from "@/hooks/queries/useLeaderboard";
 import { styled } from "@mui/material";
 import Pagination from "@mui/material/Pagination";
+import PaginationItem from "@mui/material/PaginationItem";
+import {
+  ChevronFirst,
+  ChevronLast,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
 import { useId, useState } from "react";
+import { useCanvasContext } from "@/contexts";
+import { useLeaderboard } from "@/hooks/queries/useLeaderboard";
 import LeaderboardRow, { LeaderboardRowSkeleton } from "./LeaderboardRow";
 
 const Wrapper = styled("div")`
@@ -36,6 +43,13 @@ const NoContentsMessage = styled("p")`
   letter-spacing: 0.04em;
   text-align: center;
 `;
+
+const customIconSlots = {
+  first: ChevronFirst,
+  previous: ChevronLeft,
+  next: ChevronRight,
+  last: ChevronLast,
+};
 
 export default function Leaderboard() {
   const { canvas } = useCanvasContext();
@@ -86,6 +100,9 @@ export default function Leaderboard() {
         count={total ? Math.ceil(total / size) : currentPage}
         onChange={(_, value) => setPage(value)}
         page={page}
+        renderItem={(item) => (
+          <PaginationItem slots={customIconSlots} {...item} />
+        )}
         shape="rounded"
         showFirstButton
         showLastButton

--- a/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
+++ b/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
@@ -53,8 +53,9 @@ const Username = styled("div")`
 `;
 
 const PixelCount = styled("div")`
-  font-weight: 500;
   color: oklch(from var(--discord-white) l c h / 55%);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
 `;
 
 const StyledAvatar = styled(Avatar)`

--- a/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
+++ b/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
@@ -101,7 +101,8 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
       <UsernameWrapper>
         <Username>{entry.username ?? entry.userId}</Username>
         <PixelCount>
-          {entry.totalPixels.toLocaleString()}&nbsp;pixels
+          {entry.totalPixels.toLocaleString()}&nbsp;
+          {entry.totalPixels === 1 ? "pixel" : "pixels"}
         </PixelCount>
       </UsernameWrapper>
       <StyledAvatar

--- a/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
+++ b/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
@@ -1,72 +1,65 @@
 "use client";
 
 import { LeaderboardEntry } from "@blurple-canvas-web/types";
-import { css, Skeleton, styled } from "@mui/material";
+import { Skeleton, styled } from "@mui/material";
 import Avatar, { AvatarSkeleton } from "@/components/Avatar";
 
-const RankCell = styled("td", {
-  shouldForwardProp: (prop) => prop !== "isLoading",
-})<{
-  isLoading?: boolean;
-}>`
-  color: oklch(from var(--discord-white) l c h / 45%);
+const TableRow = styled("li")`
+  align-items: baseline;
+  border-end-end-radius: calc(infinity * 1px);
+  border-end-start-radius: var(--card-border-radius);
+  border-start-end-radius: calc(infinity * 1px);
+  border-start-start-radius: var(--card-border-radius);
+  column-gap: 1.25rem;
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  grid-template-rows: auto auto;
+  padding: 1rem;
 
-  ${(props) =>
-    props.isLoading &&
-    css`
-      visibility: hidden;
-    `};
-`;
-
-const AvatarCell = styled("td")`
-  --avatar-size: clamp(2.5rem, 8svi, 3.75rem);
-  --width: calc(var(--avatar-size) + 2 * var(--cell-padding));
-
-  // We need to define the width here so that the cell doesn't get wider than the avatar.
-  width: var(--width);
-  min-width: var(--width);
-  max-width: var(--width);
-
-  > * {
-    max-height: var(--avatar-size);
+  @media (hover: hover) and (pointer: fine) {
+    &:not([aria-busy="true"]):hover {
+      background-color: oklch(from currentColor l c h / 3%);
+    }
   }
 `;
 
-const UsernameCell = styled("td")`
-  font-stretch: 125%;
-  font-weight: 900;
-  font-width: 125%;
-  text-align: start;
-`;
-
-const Username = styled("p")`
-  word-break: break-all;
-`;
-
-const PixelCountCell = styled("td")`
-  text-align: center;
-`;
-
-const PixelCountCellContents = styled("div")`
+const Rank = styled("div")`
+  color: oklch(from currentColor l c h / 45%);
   display: grid;
-  place-items: center;
-`;
-
-const PixelCount = styled("span")`
-  font-stretch: 125%;
+  font-variant-numeric: tabular-nums;
   font-weight: 900;
+  grid-row: 1 / -1;
+  grid-template-columns: subgrid;
+  text-align: center;
+  [aria-hidden="true"] {
+    visibility: hidden;
+  }
 `;
 
-const PixelCountLabel = styled("span")`
-  color: oklch(from var(--discord-white) l c h / 55%);
-  font-size: clamp(0.75rem, 2svi, 0.9rem);
+const UsernameWrapper = styled("div")`
+  text-align: start;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-row: 1 / -1;
+`;
+
+const Username = styled("div")`
+  font-stretch: 125%;
+  font-width: 125%;
   font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  word-break: break-all;
+  letter-spacing: 0.01em;
 `;
 
-const PixelCountSkeleton = styled(Skeleton)`
-  width: clamp(4.5rem, 12svi, 5.5rem);
+const PixelCount = styled("div")`
+  font-weight: 500;
+  color: oklch(from var(--discord-white) l c h / 55%);
+`;
+
+const StyledAvatar = styled(Avatar)`
+  align-self: center;
+  grid-row: 1 / -1;
 `;
 
 interface LoadingEntry extends Pick<LeaderboardEntry, "userId" | "rank"> {
@@ -85,44 +78,37 @@ export interface LeaderboardRowProps {
 
 export function LeaderboardRowSkeleton() {
   return (
-    <tr>
-      <RankCell isLoading>
-        <Skeleton variant="text" width="2ch" />
-      </RankCell>
-      <AvatarCell>
-        <AvatarSkeleton />
-      </AvatarCell>
-      <UsernameCell>
-        <Skeleton variant="rounded" width="clamp(10rem, 35svi, 16rem)" />
-      </UsernameCell>
-      <PixelCountCell>
-        <PixelCountCellContents>
-          <PixelCountSkeleton />
-        </PixelCountCellContents>
-      </PixelCountCell>
-    </tr>
+    <TableRow aria-busy>
+      <Rank>
+        <Skeleton width="2ch" />
+      </Rank>
+      <UsernameWrapper>
+        <Skeleton width="min(24ch, 100%)" />
+        <Skeleton width="min(10ch, 100%)" />
+      </UsernameWrapper>
+      <AvatarSkeleton
+        size={60}
+        sx={{ alignSelf: "center", gridRow: "1 / -1" }}
+      />
+    </TableRow>
   );
 }
 
 export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
   return (
-    <tr>
-      <RankCell>{entry.rank.toLocaleString()}</RankCell>
-      <AvatarCell>
-        <Avatar
-          username={entry.username ?? entry.userId}
-          profilePictureUrl={entry.profilePictureUrl}
-        />
-      </AvatarCell>
-      <UsernameCell>
+    <TableRow>
+      <Rank>{entry.rank.toLocaleString()}</Rank>
+      <UsernameWrapper>
         <Username>{entry.username ?? entry.userId}</Username>
-      </UsernameCell>
-      <PixelCountCell>
-        <PixelCountCellContents>
-          <PixelCount>{entry.totalPixels.toLocaleString()}</PixelCount>
-          <PixelCountLabel>pixels placed</PixelCountLabel>
-        </PixelCountCellContents>
-      </PixelCountCell>
-    </tr>
+        <PixelCount>
+          {entry.totalPixels.toLocaleString()}&nbsp;pixels
+        </PixelCount>
+      </UsernameWrapper>
+      <StyledAvatar
+        profilePictureUrl={entry.profilePictureUrl}
+        size={60}
+        username={entry.username ?? entry.userId}
+      />
+    </TableRow>
   );
 }

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -3,49 +3,81 @@
 import { DiscordUserProfile } from "@blurple-canvas-web/types";
 import { Skeleton, styled } from "@mui/material";
 
-type AvatarProps = Pick<
-  DiscordUserProfile,
-  "username" | "profilePictureUrl"
-> & {
+interface AvatarProps
+  extends
+    Pick<DiscordUserProfile, "username" | "profilePictureUrl">,
+    React.ComponentPropsWithRef<"object"> {
   /** In pixels */
   size?: number;
-};
+}
 
 const StyledObject = styled("object")`
-  --stroke-width: max(0.125rem, 1px);
-
+  aspect-ratio: 1;
   border-radius: calc(infinity * 1px);
-  outline: oklch(from var(--discord-white) l c h / 12%) var(--stroke-width)
-    solid;
-  outline-offset: calc(-1 * var(--stroke-width));
+  border: oklch(from var(--discord-white) l c h / 12%) 1px solid;
+  object-fit: cover;
+  overflow: hidden;
 `;
 
 const AvatarImage = styled("img")`
   border-radius: inherit;
+  outline: inherit;
+  outline-offset: inherit;
+  aspect-ratio: 1;
+  object-fit: cover;
 `;
 
 export default function Avatar({
   username,
   profilePictureUrl,
   size,
+  ...props
 }: AvatarProps) {
+  const hash = (username.length % 6) as 0 | 1 | 2 | 3 | 4 | 5;
   return (
-    <StyledObject data={profilePictureUrl} width={size} height={size}>
+    <StyledObject
+      data={profilePictureUrl}
+      role="img"
+      width={size}
+      height={size}
+      style={{
+        minHeight: size,
+        minWidth: size,
+        height: size,
+        width: size,
+      }}
+      {...props}
+    >
       <AvatarImage
         alt={`${username}’s avatar`}
-        src="https://cdn.discordapp.com/embed/avatars/1.png"
+        src={`https://cdn.discordapp.com/embed/avatars/${hash}.png`}
+        width={size}
+        height={size}
+        style={{
+          minHeight: size,
+          minWidth: size,
+          height: size,
+          width: size,
+        }}
       />
     </StyledObject>
   );
 }
 
-export function AvatarSkeleton() {
+interface AvatarSkeletonProps extends React.ComponentPropsWithoutRef<
+  typeof Skeleton
+> {
+  size?: string | number | undefined;
+}
+
+export function AvatarSkeleton({ size, sx, ...props }: AvatarSkeletonProps) {
   return (
     <Skeleton
       variant="circular"
-      width="100%"
-      height="auto"
-      sx={{ aspectRatio: 1 }}
+      width={size ?? "100%"}
+      height={size ?? "auto"}
+      sx={{ aspectRatio: 1, ...sx }}
+      {...props}
     />
   );
 }

--- a/packages/frontend/src/hooks/queries/useLeaderboard.tsx
+++ b/packages/frontend/src/hooks/queries/useLeaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CanvasInfo, LeaderboardRequest } from "@blurple-canvas-web/types";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config";
 
@@ -21,6 +21,7 @@ export function useLeaderboard(
   return useQuery({
     queryKey: ["leaderboard", canvasId, { page, size }],
     queryFn: getLeaderboard,
+    placeholderData: keepPreviousData,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     staleTime: 30_000, // 30 seconds

--- a/packages/frontend/src/hooks/queries/useLeaderboard.tsx
+++ b/packages/frontend/src/hooks/queries/useLeaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CanvasInfo, LeaderboardRequest } from "@blurple-canvas-web/types";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config";
 

--- a/packages/frontend/src/theme/theme.ts
+++ b/packages/frontend/src/theme/theme.ts
@@ -74,5 +74,12 @@ export const Theme = createTheme({
         },
       },
     },
+    MuiPaginationItem: {
+      styleOverrides: {
+        root: {
+          transitionProperty: "none",
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
There’s still a slight misalignment with the fallback avatars, but it’s an improvement. Can always revisit in subsequent PR.

<img width="904" height="1468" alt="Screenshot 2026-04-22T143045" src="https://github.com/user-attachments/assets/36089abb-7674-4da6-8d60-77cc3f86d03c" />
