### PR TITLE
fix(frontend): keep non-canvas routes when switching canvas

### DIFF
--- a/packages/frontend/src/contexts/CanvasContext.tsx
+++ b/packages/frontend/src/contexts/CanvasContext.tsx
@@ -56,11 +56,22 @@ export const CanvasProvider = ({
       setCoords(null);
       setFrame(null);
 
+      // Only rewrite the URL when the user is on a canvas-bound route
+      // (/, /canvas, /canvas/:id). Other pages like /leaderboard or /me
+      // read the active canvas from context and should stay put when the
+      // user switches canvases — redirecting home in those cases was the
+      // bug reported in #442.
       const url = new URL(window.location.href);
-      url.pathname =
-        canvasId === mainCanvasInfo.id ? "/" : `/canvas/${canvasId}`;
-      url.search = "";
-      router.replace(`${url.pathname}${url.search}${url.hash}`);
+      const isCanvasRoute =
+        url.pathname === "/" ||
+        url.pathname === "/canvas" ||
+        url.pathname.startsWith("/canvas/");
+      if (isCanvasRoute) {
+        url.pathname =
+          canvasId === mainCanvasInfo.id ? "/" : `/canvas/${canvasId}`;
+        url.search = "";
+        router.replace(`${url.pathname}${url.search}${url.hash}`);
+      }
 
       // When we load an image, we want to make sure any pixels placed since now get included in the
       // response. This is because in the time it takes for the image to load some pixels may have


### PR DESCRIPTION
## Summary
Only rewrite the URL in `setCanvasById` when the user is on a canvas-bound route (`/`, `/canvas`, `/canvas/:id`). The leaderboard, profile, and any other non-canvas pages now stay put when a user switches canvases instead of redirecting home.

## Why this matters
Issue #442: on `/leaderboard`, switching the active canvas in `CanvasPicker` pops you back to `/`. `setCanvasById` in `packages/frontend/src/contexts/CanvasContext.tsx:49` always set `url.pathname` to either `/` (main canvas) or `/canvas/:id`, then called `router.replace` - no matter what page the user was on. For leaderboard / me pages that read the canvas from context, this redirect was unintended.

## Changes
- `packages/frontend/src/contexts/CanvasContext.tsx`:
  - Gate the URL rewrite + `router.replace` behind an `isCanvasRoute` check. Non-canvas routes skip the replace entirely.
  - Every other side effect - `setActiveCanvas`, `setColor`, `setCoords`, `setFrame`, `socket.auth` - runs unchanged, so the context value still updates and leaderboard / me re-render against the newly selected canvas.
  - Short comment at the call site pointing at #442 so the next person doesn't re-introduce the old unconditional replace.

## Testing
```
$ cd packages/frontend && npx tsc --noEmit
$ echo $?
0
```

No type errors. Manual steps after the patch:
1. Go to `/leaderboard`.
2. Open `CanvasPicker`, switch to a different canvas.
3. The leaderboard re-renders with the new canvas's data; URL stays `/leaderboard` (previously redirected to `/` or `/canvas/:id`).
4. Switching canvas from `/` still navigates to `/canvas/:id` (and back to `/` for the main canvas) - no regression on canvas-bound routes.

Fixes #442

This contribution was developed with AI assistance (Claude Code).
