### PR TITLE
chore(lint): use `import type`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,7 @@
   "linter": {
     "rules": {
       "style": {
-        "useImportType": "off"
+        "useImportType": "error"
       },
       "suspicious": {
         "noArrayIndexKey": "warn"

--- a/packages/backend/src/app/SocketHandler.ts
+++ b/packages/backend/src/app/SocketHandler.ts
@@ -1,5 +1,5 @@
-import { PlacePixelSocket } from "@blurple-canvas-web/types";
-import { Server, Socket } from "socket.io";
+import type { PlacePixelSocket } from "@blurple-canvas-web/types";
+import type { Server, Socket } from "socket.io";
 import { prisma } from "@/client";
 
 const TEN_MINUTES_IN_MS = 10 * 60 * 1000;

--- a/packages/backend/src/errors/ApiError.ts
+++ b/packages/backend/src/errors/ApiError.ts
@@ -1,4 +1,4 @@
-import { Response } from "express";
+import type { Response } from "express";
 
 export default class ApiError extends Error {
   constructor(

--- a/packages/backend/src/errors/BadRequestError.ts
+++ b/packages/backend/src/errors/BadRequestError.ts
@@ -1,5 +1,5 @@
-import { Response } from "express";
-import { ZodIssue } from "zod";
+import type { Response } from "express";
+import type { ZodIssue } from "zod";
 import ApiError from "./ApiError";
 
 export default class BadRequestError extends ApiError {

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -1,6 +1,6 @@
-import { DiscordUserProfile } from "@blurple-canvas-web/types";
+import type { DiscordUserProfile } from "@blurple-canvas-web/types";
 import { PrismaSessionStore } from "@quixo3/prisma-session-store";
-import { Express } from "express";
+import type { Express } from "express";
 import session from "express-session";
 import passport from "passport";
 import { Strategy as DiscordStrategy } from "passport-discord";

--- a/packages/backend/src/models/paramModels.ts
+++ b/packages/backend/src/models/paramModels.ts
@@ -1,4 +1,4 @@
-import { CanvasInfo } from "@blurple-canvas-web/types";
+import type { CanvasInfo } from "@blurple-canvas-web/types";
 import z from "zod";
 import BadRequestError from "@/errors/BadRequestError";
 

--- a/packages/backend/src/routes/api/v1/canvas.ts
+++ b/packages/backend/src/routes/api/v1/canvas.ts
@@ -1,8 +1,8 @@
-import { Response, Router } from "express";
+import { type Response, Router } from "express";
 import { ApiError } from "@/errors";
 import { parseCanvasId } from "@/models/paramModels";
 import {
-  CachedCanvas,
+  type CachedCanvas,
   getCanvases,
   getCanvasFilename,
   getCanvasInfo,

--- a/packages/backend/src/routes/api/v1/discord.ts
+++ b/packages/backend/src/routes/api/v1/discord.ts
@@ -1,4 +1,4 @@
-import { DiscordUserProfile, GuildData } from "@blurple-canvas-web/types";
+import type { DiscordUserProfile, GuildData } from "@blurple-canvas-web/types";
 import { Router } from "express";
 import passport from "passport";
 

--- a/packages/backend/src/routes/api/v1/pixel.ts
+++ b/packages/backend/src/routes/api/v1/pixel.ts
@@ -1,4 +1,4 @@
-import { DiscordUserProfile, Point } from "@blurple-canvas-web/types";
+import type { DiscordUserProfile, Point } from "@blurple-canvas-web/types";
 import { Router } from "express";
 import config from "@/config";
 import {
@@ -14,7 +14,7 @@ import {
   PlacePixelBodyModel,
 } from "@/models/bodyModels";
 import {
-  CanvasIdParam,
+  type CanvasIdParam,
   PixelHistoryParamModel,
   parseCanvasId,
 } from "@/models/paramModels";

--- a/packages/backend/src/services/canvasService.ts
+++ b/packages/backend/src/services/canvasService.ts
@@ -1,15 +1,15 @@
 import fs from "node:fs";
-import {
+import type {
   CanvasInfo,
   CanvasSummary,
   PixelColor,
   Point,
 } from "@blurple-canvas-web/types";
 import { PNG } from "pngjs";
-import { canvas, prisma } from "@/client";
+import { type canvas, prisma } from "@/client";
 import config from "@/config";
 import { NotFoundError } from "@/errors";
-import { PlacePixelArray } from "@/models/bodyModels";
+import type { PlacePixelArray } from "@/models/bodyModels";
 
 /**
  * A locked canvas cannot be edited by users. It is therefore, safe to store it as an image on the

--- a/packages/backend/src/services/discordGuildService.ts
+++ b/packages/backend/src/services/discordGuildService.ts
@@ -1,4 +1,4 @@
-import { DiscordUserProfile, GuildData } from "@blurple-canvas-web/types";
+import type { DiscordUserProfile, GuildData } from "@blurple-canvas-web/types";
 import config from "@/config";
 import BadRequestError from "@/errors/BadRequestError";
 import ForbiddenError from "@/errors/ForbiddenError";

--- a/packages/backend/src/services/discordProfileService.ts
+++ b/packages/backend/src/services/discordProfileService.ts
@@ -1,5 +1,5 @@
-import { DiscordUserProfile } from "@blurple-canvas-web/types";
-import { discord_user_profile, prisma } from "@/client";
+import type { DiscordUserProfile } from "@blurple-canvas-web/types";
+import { type discord_user_profile, prisma } from "@/client";
 import { NotFoundError } from "@/errors";
 
 export async function getDiscordProfile(

--- a/packages/backend/src/services/eventService.ts
+++ b/packages/backend/src/services/eventService.ts
@@ -1,4 +1,4 @@
-import { BlurpleEvent } from "@blurple-canvas-web/types";
+import type { BlurpleEvent } from "@blurple-canvas-web/types";
 import { prisma } from "@/client";
 import { NotFoundError } from "@/errors";
 

--- a/packages/backend/src/services/frameService.ts
+++ b/packages/backend/src/services/frameService.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DiscordUserProfile,
   Frame,
   GuildOwnedFrame,

--- a/packages/backend/src/services/paletteService.ts
+++ b/packages/backend/src/services/paletteService.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   PaletteColor,
   PaletteColorSummary,
   PixelColor,
 } from "@blurple-canvas-web/types";
 
-import { color, prisma } from "@/client";
+import { type color, prisma } from "@/client";
 import { getCurrentEvent } from "./eventService";
 
 type ColorSummary = Pick<color, "id" | "code" | "name" | "rgba" | "global">;

--- a/packages/backend/src/services/pixelService.ts
+++ b/packages/backend/src/services/pixelService.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   PaletteColor,
   PixelColor,
   PixelHistoryWrapper,
   Point,
 } from "@blurple-canvas-web/types";
 
-import { color, prisma } from "@/client";
+import { type color, prisma } from "@/client";
 import config from "@/config";
 import { BadRequestError, ForbiddenError, NotFoundError } from "@/errors";
 import { socketHandler } from "@/index";

--- a/packages/backend/src/services/statisticsService.ts
+++ b/packages/backend/src/services/statisticsService.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CanvasInfo,
   LeaderboardEntry,
   Paginated,

--- a/packages/backend/src/test/mockAuth.ts
+++ b/packages/backend/src/test/mockAuth.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 
 /* This function should be used as a middleware in testing to bypass the need to mock a passport strategy */
 export const mockAuth = (req: Request, _res: Response, next: NextFunction) => {

--- a/packages/backend/src/test/vitest.setup.ts
+++ b/packages/backend/src/test/vitest.setup.ts
@@ -1,6 +1,6 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { afterAll, afterEach, beforeEach, vi } from "vitest";
-import { Prisma, PrismaClient } from "@/client/generated/client";
+import { type Prisma, PrismaClient } from "@/client/generated/client";
 
 const adapter = new PrismaPg(process.env.DATABASE_URL!);
 const prismaClient = new PrismaClient({ adapter });

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import {
+import type {
   CanvasInfo,
   CanvasInfoRequest,
   DiscordUserProfile,

--- a/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
+++ b/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LeaderboardEntry } from "@blurple-canvas-web/types";
+import type { LeaderboardEntry } from "@blurple-canvas-web/types";
 import { Skeleton, styled } from "@mui/material";
 import Avatar, { AvatarSkeleton } from "@/components/Avatar";
 

--- a/packages/frontend/src/app/me/StatsTable.tsx
+++ b/packages/frontend/src/app/me/StatsTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { UserStats } from "@blurple-canvas-web/types";
+import type { UserStats } from "@blurple-canvas-web/types";
 import { Skeleton, styled } from "@mui/material";
 import {
   formatTimestamp,

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DiscordUserProfile } from "@blurple-canvas-web/types";
+import type { DiscordUserProfile } from "@blurple-canvas-web/types";
 import { Skeleton, styled } from "@mui/material";
 
 interface AvatarProps

--- a/packages/frontend/src/components/ColorCodeChip.tsx
+++ b/packages/frontend/src/components/ColorCodeChip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PaletteColorSummary } from "@blurple-canvas-web/types";
+import type { PaletteColorSummary } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material";
 
 const Container = styled("code", {

--- a/packages/frontend/src/components/action-panel/ActionPanel.tsx
+++ b/packages/frontend/src/components/action-panel/ActionPanel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { PaletteColor } from "@blurple-canvas-web/types";
+import type { PaletteColor } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material";
-import React, { useId, useState } from "react";
+import type React from "react";
+import { useId, useState } from "react";
 import {
   useCanvasContext,
   useCanvasViewContext,

--- a/packages/frontend/src/components/action-panel/tabs/ActionPanelTabBody.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/ActionPanelTabBody.tsx
@@ -1,5 +1,5 @@
 import { styled } from "@mui/material";
-import React from "react";
+import type React from "react";
 
 export const ActionPanelTabBody = styled("div")`
   display: block flex;

--- a/packages/frontend/src/components/action-panel/tabs/ActionPanelTooltip.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/ActionPanelTooltip.tsx
@@ -1,4 +1,4 @@
-import Tooltip, { TooltipProps } from "@mui/material/Tooltip";
+import Tooltip, { type TooltipProps } from "@mui/material/Tooltip";
 import { useState } from "react";
 import DynamicButton from "@/components/button/DynamicButton";
 

--- a/packages/frontend/src/components/action-panel/tabs/CoordinatesCard.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/CoordinatesCard.tsx
@@ -1,4 +1,4 @@
-import { Point } from "@blurple-canvas-web/types";
+import type { Point } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material";
 
 const Wrapper = styled("div")`

--- a/packages/frontend/src/components/action-panel/tabs/FramePreviewList.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/FramePreviewList.tsx
@@ -1,4 +1,4 @@
-import { Frame } from "@blurple-canvas-web/types";
+import type { Frame } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material/styles";
 import { FrameThumbCard } from "./FrameThumbCard";
 

--- a/packages/frontend/src/components/action-panel/tabs/FrameThumbCard.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/FrameThumbCard.tsx
@@ -1,4 +1,4 @@
-import { Frame } from "@blurple-canvas-web/types";
+import type { Frame } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material/styles";
 import { useEffect, useRef } from "react";
 import { useCanvasContext } from "@/contexts";

--- a/packages/frontend/src/components/action-panel/tabs/FramesTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/FramesTab.tsx
@@ -1,6 +1,6 @@
-import { ValueOf } from "@blurple-canvas-web/types";
+import type { ValueOf } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material";
-import { ReactNode, useState } from "react";
+import { type ReactNode, useState } from "react";
 import FrameEditPanel from "@/components/frames/FrameEditPanel";
 import FrameInfoPanel from "@/components/frames/FrameInfoPanel";
 import { TabPanel } from "./ActionPanelTabBody";

--- a/packages/frontend/src/components/action-panel/tabs/PixelHistoryListItem.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PixelHistoryListItem.tsx
@@ -1,4 +1,4 @@
-import { PixelHistoryRecord } from "@blurple-canvas-web/types";
+import type { PixelHistoryRecord } from "@blurple-canvas-web/types";
 import { Skeleton, styled } from "@mui/material";
 
 import ColorCodeChip from "@/components/ColorCodeChip";

--- a/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
@@ -1,4 +1,4 @@
-import { PixelHistoryRecord } from "@blurple-canvas-web/types";
+import type { PixelHistoryRecord } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material";
 import { useCanvasContext, useCanvasViewContext } from "@/contexts";
 import { usePixelHistory } from "@/hooks";

--- a/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
@@ -1,4 +1,4 @@
-import { DiscordUserProfile, Palette } from "@blurple-canvas-web/types";
+import type { DiscordUserProfile, Palette } from "@blurple-canvas-web/types";
 import { Skeleton, styled } from "@mui/material";
 import { useCallback, useEffect, useState } from "react";
 import {

--- a/packages/frontend/src/components/action-panel/tabs/SelectedColorInfoCard.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/SelectedColorInfoCard.tsx
@@ -1,4 +1,4 @@
-import { PaletteColor } from "@blurple-canvas-web/types";
+import type { PaletteColor } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material";
 import { useCanvasContext } from "@/contexts";
 

--- a/packages/frontend/src/components/button/DynamicButton.tsx
+++ b/packages/frontend/src/components/button/DynamicButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PixelColor } from "@blurple-canvas-web/types";
+import type { PixelColor } from "@blurple-canvas-web/types";
 import { buttonClasses, css, styled } from "@mui/material";
 
 import { Button as ButtonBase } from "@/components/button";

--- a/packages/frontend/src/components/button/PlacePixelButton.tsx
+++ b/packages/frontend/src/components/button/PlacePixelButton.tsx
@@ -1,4 +1,4 @@
-import { Cooldown } from "@blurple-canvas-web/types";
+import type { Cooldown } from "@blurple-canvas-web/types";
 import { CircularProgress, styled } from "@mui/material";
 import axios from "axios";
 import { useEffect, useState } from "react";

--- a/packages/frontend/src/components/canvas/CanvasPicker.tsx
+++ b/packages/frontend/src/components/canvas/CanvasPicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CanvasSummary } from "@blurple-canvas-web/types";
+import type { CanvasSummary } from "@blurple-canvas-web/types";
 import { NativeSelect, nativeSelectClasses, styled } from "@mui/material";
 import { ChevronsUpDown } from "lucide-react";
 import { useCanvasContext } from "@/contexts";

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {
+import type {
   CanvasInfo,
   Frame,
   PlacePixelSocket,
@@ -19,7 +19,7 @@ import {
 } from "@/contexts";
 import { useCanvasImage, useCanvasSearchParams } from "@/hooks";
 import { useFrameById } from "@/hooks/queries/useFrame";
-import { CanvasSearchParams } from "@/hooks/useCanvasSearchParams";
+import type { CanvasSearchParams } from "@/hooks/useCanvasSearchParams";
 import { socket } from "@/socket";
 import { clamp, normalizeFrameBounds } from "@/util";
 import { Button } from "../button";

--- a/packages/frontend/src/components/canvas/SelectedBoundsOverlay.tsx
+++ b/packages/frontend/src/components/canvas/SelectedBoundsOverlay.tsx
@@ -1,7 +1,13 @@
-import { Point } from "@blurple-canvas-web/types";
+import type { Point } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material";
-import { Dispatch, PointerEvent, SetStateAction, useMemo, useRef } from "react";
-import { clamp, ViewBounds } from "@/util";
+import {
+  type Dispatch,
+  type PointerEvent,
+  type SetStateAction,
+  useMemo,
+  useRef,
+} from "react";
+import { clamp, type ViewBounds } from "@/util";
 
 const OverlayReticleContainer = styled("div")`
   position: absolute;

--- a/packages/frontend/src/components/canvas/point.ts
+++ b/packages/frontend/src/components/canvas/point.ts
@@ -1,4 +1,4 @@
-import { Point } from "@blurple-canvas-web/types";
+import type { Point } from "@blurple-canvas-web/types";
 
 export const ORIGIN: Point = { x: 0, y: 0 };
 

--- a/packages/frontend/src/components/frames/FrameEditPanel.tsx
+++ b/packages/frontend/src/components/frames/FrameEditPanel.tsx
@@ -1,4 +1,4 @@
-import {
+import type {
   FrameOwnerType,
   GuildData,
   GuildOwnedFrame,
@@ -19,8 +19,8 @@ import { styled } from "@mui/material/styles";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import {
-  Dispatch,
-  SetStateAction,
+  type Dispatch,
+  type SetStateAction,
   useEffect,
   useMemo,
   useRef,
@@ -38,7 +38,7 @@ import { useCanvasImage } from "@/hooks/useCanvasImage";
 import {
   hexStringToPixelColor,
   normalizeFrameBounds,
-  ViewBounds,
+  type ViewBounds,
 } from "@/util";
 import { Heading } from "../action-panel/ActionPanel";
 import {

--- a/packages/frontend/src/components/frames/FrameInfoPanel.tsx
+++ b/packages/frontend/src/components/frames/FrameInfoPanel.tsx
@@ -1,4 +1,4 @@
-import { DiscordUserProfile, Frame } from "@blurple-canvas-web/types";
+import type { DiscordUserProfile, Frame } from "@blurple-canvas-web/types";
 import {
   useAuthContext,
   useCanvasContext,

--- a/packages/frontend/src/components/frames/FrameList.tsx
+++ b/packages/frontend/src/components/frames/FrameList.tsx
@@ -1,4 +1,4 @@
-import {
+import type {
   FrameRequest,
   GuildOwnedFrame,
   SystemOwnedFrame,

--- a/packages/frontend/src/components/frames/FramePreview.tsx
+++ b/packages/frontend/src/components/frames/FramePreview.tsx
@@ -1,4 +1,4 @@
-import { Frame } from "@blurple-canvas-web/types";
+import type { Frame } from "@blurple-canvas-web/types";
 import { styled } from "@mui/material/styles";
 import { clamp, normalizeFrameBounds } from "@/util";
 

--- a/packages/frontend/src/components/swatch/InteractiveSwatch.tsx
+++ b/packages/frontend/src/components/swatch/InteractiveSwatch.tsx
@@ -1,6 +1,6 @@
 import { styled } from "@mui/material";
 
-import { StaticSwatchProps } from "./StaticSwatch";
+import type { StaticSwatchProps } from "./StaticSwatch";
 import { SwatchBase } from "./SwatchBase";
 
 const StyledSwatchBase = styled(SwatchBase)`

--- a/packages/frontend/src/components/swatch/StaticSwatch.tsx
+++ b/packages/frontend/src/components/swatch/StaticSwatch.tsx
@@ -1,4 +1,4 @@
-import { PaletteColor } from "@blurple-canvas-web/types";
+import type { PaletteColor } from "@blurple-canvas-web/types";
 import { SwatchBase } from "./SwatchBase";
 
 export interface StaticSwatchProps {

--- a/packages/frontend/src/contexts/AuthProvider.tsx
+++ b/packages/frontend/src/contexts/AuthProvider.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { DiscordUserProfile } from "@blurple-canvas-web/types";
+import type { DiscordUserProfile } from "@blurple-canvas-web/types";
 import axios from "axios";
 import Cookies from "js-cookie";
 import {
   createContext,
-  ReactNode,
+  type ReactNode,
   useCallback,
   useContext,
   useState,

--- a/packages/frontend/src/contexts/CanvasContext.tsx
+++ b/packages/frontend/src/contexts/CanvasContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CanvasInfo, CanvasInfoRequest } from "@blurple-canvas-web/types";
+import type { CanvasInfo, CanvasInfoRequest } from "@blurple-canvas-web/types";
 import axios from "axios";
 import { useRouter } from "next/navigation";
 import { createContext, useCallback, useContext, useState } from "react";

--- a/packages/frontend/src/contexts/CanvasViewContext.tsx
+++ b/packages/frontend/src/contexts/CanvasViewContext.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Point } from "@blurple-canvas-web/types";
+import type { Point } from "@blurple-canvas-web/types";
 import {
   createContext,
-  Dispatch,
-  RefObject,
-  SetStateAction,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
   useContext,
   useMemo,
   useRef,

--- a/packages/frontend/src/contexts/SelectedBoundsContext.tsx
+++ b/packages/frontend/src/contexts/SelectedBoundsContext.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { CanvasInfo, Point } from "@blurple-canvas-web/types";
+import type { CanvasInfo, Point } from "@blurple-canvas-web/types";
 import {
   createContext,
-  Dispatch,
-  RefObject,
-  SetStateAction,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
   useCallback,
   useContext,
   useState,
 } from "react";
-import { ViewBounds } from "@/util";
+import type { ViewBounds } from "@/util";
 import { useCanvasContext } from "./CanvasContext";
 import { useCanvasViewContext } from "./CanvasViewContext";
 

--- a/packages/frontend/src/contexts/SelectedColorContext.tsx
+++ b/packages/frontend/src/contexts/SelectedColorContext.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { PaletteColor } from "@blurple-canvas-web/types";
+import type { PaletteColor } from "@blurple-canvas-web/types";
 import {
   createContext,
-  Dispatch,
-  SetStateAction,
+  type Dispatch,
+  type SetStateAction,
   useContext,
   useState,
 } from "react";

--- a/packages/frontend/src/contexts/SelectedFrameContext.tsx
+++ b/packages/frontend/src/contexts/SelectedFrameContext.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Frame } from "@blurple-canvas-web/types";
+import type { Frame } from "@blurple-canvas-web/types";
 import {
   createContext,
-  Dispatch,
-  SetStateAction,
+  type Dispatch,
+  type SetStateAction,
   useContext,
   useState,
 } from "react";

--- a/packages/frontend/src/hooks/queries/useCanvasInfo.tsx
+++ b/packages/frontend/src/hooks/queries/useCanvasInfo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CanvasInfo, CanvasInfoRequest } from "@blurple-canvas-web/types";
+import type { CanvasInfo, CanvasInfoRequest } from "@blurple-canvas-web/types";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config";

--- a/packages/frontend/src/hooks/queries/useCanvasList.tsx
+++ b/packages/frontend/src/hooks/queries/useCanvasList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CanvasListRequest } from "@blurple-canvas-web/types";
+import type { CanvasListRequest } from "@blurple-canvas-web/types";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config";

--- a/packages/frontend/src/hooks/queries/useEventInfo.tsx
+++ b/packages/frontend/src/hooks/queries/useEventInfo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BlurpleEvent, EventRequest } from "@blurple-canvas-web/types";
+import type { BlurpleEvent, EventRequest } from "@blurple-canvas-web/types";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config";

--- a/packages/frontend/src/hooks/queries/useFrame.tsx
+++ b/packages/frontend/src/hooks/queries/useFrame.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import {
+import type {
   DiscordGuildRecord,
   DiscordUserProfile,
   Frame,
   FrameRequest,
 } from "@blurple-canvas-web/types";
-import { UseQueryOptions, useQuery } from "@tanstack/react-query";
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config";
 

--- a/packages/frontend/src/hooks/queries/useLeaderboard.tsx
+++ b/packages/frontend/src/hooks/queries/useLeaderboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CanvasInfo, LeaderboardRequest } from "@blurple-canvas-web/types";
+import type { CanvasInfo, LeaderboardRequest } from "@blurple-canvas-web/types";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config";

--- a/packages/frontend/src/hooks/queries/usePalette.tsx
+++ b/packages/frontend/src/hooks/queries/usePalette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {
+import type {
   BlurpleEvent,
   PaletteColor,
   PaletteRequest,

--- a/packages/frontend/src/hooks/queries/usePixelHistory.tsx
+++ b/packages/frontend/src/hooks/queries/usePixelHistory.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { CanvasInfo, HistoryRequest, Point } from "@blurple-canvas-web/types";
+import type {
+  CanvasInfo,
+  HistoryRequest,
+  Point,
+} from "@blurple-canvas-web/types";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config";

--- a/packages/frontend/src/hooks/queries/useUserData.tsx
+++ b/packages/frontend/src/hooks/queries/useUserData.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DiscordUserProfile } from "@blurple-canvas-web/types";
+import type { DiscordUserProfile } from "@blurple-canvas-web/types";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config";

--- a/packages/frontend/src/hooks/queries/useUserStats.tsx
+++ b/packages/frontend/src/hooks/queries/useUserStats.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {
+import type {
   CanvasInfo,
   DiscordUserProfile,
   UserStatsRequest,

--- a/packages/frontend/src/util/index.ts
+++ b/packages/frontend/src/util/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DiscordUserProfile,
   Frame,
   GuildData,

--- a/packages/frontend/src/util/searchParams.ts
+++ b/packages/frontend/src/util/searchParams.ts
@@ -1,4 +1,4 @@
-import { Point } from "@blurple-canvas-web/types";
+import type { Point } from "@blurple-canvas-web/types";
 import config from "@/config";
 
 export interface SearchParamConfig {

--- a/packages/types/src/frame.ts
+++ b/packages/types/src/frame.ts
@@ -1,6 +1,6 @@
-import { DiscordGuildRecord } from "./discordGuildRecord";
-import { DiscordUserProfile } from "./discordUserProfile";
-import { Satisfies } from "./util";
+import type { DiscordGuildRecord } from "./discordGuildRecord";
+import type { DiscordUserProfile } from "./discordUserProfile";
+import type { Satisfies } from "./util";
 
 export type FrameOwnerType = "guild" | "system" | "user";
 


### PR DESCRIPTION
Will help Knip diagnose dependency issues

Use `pnpm run lint:fix` or `pnpm lint-staged` when developing locally so you don’t have to worry about manually doing this busywork