### PR TITLE
fix: skip canvas fetch on build

### DIFF
--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -55,7 +55,7 @@ async function getServerSideProfile(): Promise<DiscordUserProfile | null> {
 async function getServerSideCanvasInfo(): Promise<CanvasInfo> {
   // Skip during build - data will be fetched fresh on client startup
   if (process.env.npm_lifecycle_event === "build") {
-    return getDefaultCanvasInfo();
+    return defaultCanvasInfo;
   }
 
   try {
@@ -67,23 +67,21 @@ async function getServerSideCanvasInfo(): Promise<CanvasInfo> {
     console.error(error);
 
     // Fallback in case something goes wrong
-    return getDefaultCanvasInfo();
+    return defaultCanvasInfo;
   }
 }
 
-function getDefaultCanvasInfo(): CanvasInfo {
-  return {
-    id: 1,
-    name: "Something went wrong...",
-    isLocked: true,
-    width: 600,
-    height: 600,
-    startCoordinates: [1, 1],
-    eventId: 1,
-    webPlacingEnabled: false,
-    allColorsGlobal: false,
-  };
-}
+const defaultCanvasInfo: CanvasInfo = {
+  id: 1,
+  name: "Something went wrong...",
+  isLocked: true,
+  width: 600,
+  height: 600,
+  startCoordinates: [1, 1],
+  eventId: 1,
+  webPlacingEnabled: false,
+  allColorsGlobal: false,
+};
 
 export default async function RootLayout({
   children,

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -53,6 +53,11 @@ async function getServerSideProfile(): Promise<DiscordUserProfile | null> {
 }
 
 async function getServerSideCanvasInfo(): Promise<CanvasInfo> {
+  // Skip during build - data will be fetched fresh on client startup
+  if (process.env.npm_lifecycle_event === "build") {
+    return getDefaultCanvasInfo();
+  }
+
   try {
     const response = await axios.get<CanvasInfoRequest.ResBody>(
       `${config.apiUrl}/api/v1/canvas/current/info`,
@@ -62,18 +67,22 @@ async function getServerSideCanvasInfo(): Promise<CanvasInfo> {
     console.error(error);
 
     // Fallback in case something goes wrong
-    return {
-      id: 1,
-      name: "Something went wrong...",
-      isLocked: true,
-      width: 600,
-      height: 600,
-      startCoordinates: [1, 1],
-      eventId: 1,
-      webPlacingEnabled: false,
-      allColorsGlobal: false,
-    };
+    return getDefaultCanvasInfo();
   }
+}
+
+function getDefaultCanvasInfo(): CanvasInfo {
+  return {
+    id: 1,
+    name: "Something went wrong...",
+    isLocked: true,
+    width: 600,
+    height: 600,
+    startCoordinates: [1, 1],
+    eventId: 1,
+    webPlacingEnabled: false,
+    allColorsGlobal: false,
+  };
 }
 
 export default async function RootLayout({

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -71,7 +71,7 @@ async function getServerSideCanvasInfo(): Promise<CanvasInfo> {
   }
 }
 
-const defaultCanvasInfo: CanvasInfo = {
+const defaultCanvasInfo = {
   id: 1,
   name: "Something went wrong...",
   isLocked: true,
@@ -81,7 +81,7 @@ const defaultCanvasInfo: CanvasInfo = {
   eventId: 1,
   webPlacingEnabled: false,
   allColorsGlobal: false,
-};
+} satisfies CanvasInfo;
 
 export default async function RootLayout({
   children,


### PR DESCRIPTION
When the frontend builds, it makes a request to the backend to fetch the default canvas info. This obviously fails because it's just a build and has no access to the backend. It's only a silent non-fatal error, but this fix just skips that erroneous fetch so no more log spam whenever you build the frontend