### PR TITLE
feat(frontend): load tab data only when active

### DIFF
--- a/packages/frontend/src/components/action-panel/tabs/FramesTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/FramesTab.tsx
@@ -24,7 +24,11 @@ interface FramesTabProps extends React.ComponentPropsWithRef<
   setTabsLocked: (locked: boolean) => void;
 }
 
-export default function FramesTab({ active = false, setTabsLocked, ...props }: FramesTabProps) {
+export default function FramesTab({
+  active = false,
+  setTabsLocked,
+  ...props
+}: FramesTabProps) {
   const [activePanel, setActivePanel] = useState<FramePanelMode>(
     FramePanelMode.Info,
   );
@@ -34,7 +38,9 @@ export default function FramesTab({ active = false, setTabsLocked, ...props }: F
   }, [activePanel, setTabsLocked]);
 
   const panelByMode = {
-    [FramePanelMode.Info]: <FrameInfoPanel setActivePanel={setActivePanel} enabled={active} />,
+    [FramePanelMode.Info]: (
+      <FrameInfoPanel setActivePanel={setActivePanel} enabled={active} />
+    ),
     [FramePanelMode.Edit]: (
       <FrameEditPanel setActivePanel={setActivePanel} isCreateMode={false} />
     ),

--- a/packages/frontend/src/components/action-panel/tabs/FramesTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/FramesTab.tsx
@@ -20,10 +20,11 @@ export type FramePanelMode = ValueOf<typeof FramePanelMode>;
 interface FramesTabProps extends React.ComponentPropsWithRef<
   typeof FramesTabBlock
 > {
+  active?: boolean;
   setTabsLocked: (locked: boolean) => void;
 }
 
-export default function FramesTab({ setTabsLocked, ...props }: FramesTabProps) {
+export default function FramesTab({ active = false, setTabsLocked, ...props }: FramesTabProps) {
   const [activePanel, setActivePanel] = useState<FramePanelMode>(
     FramePanelMode.Info,
   );
@@ -33,7 +34,7 @@ export default function FramesTab({ setTabsLocked, ...props }: FramesTabProps) {
   }, [activePanel, setTabsLocked]);
 
   const panelByMode = {
-    [FramePanelMode.Info]: <FrameInfoPanel setActivePanel={setActivePanel} />,
+    [FramePanelMode.Info]: <FrameInfoPanel setActivePanel={setActivePanel} enabled={active} />,
     [FramePanelMode.Edit]: (
       <FrameEditPanel setActivePanel={setActivePanel} isCreateMode={false} />
     ),

--- a/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
@@ -79,7 +79,7 @@ export default function PixelInfoTab({
 }: PixelInfoTabProps) {
   const { canvas } = useCanvasContext();
   const { adjustedCoords, containerRef, coords, zoom } = useCanvasViewContext();
-  const { data, isLoading } = usePixelHistory(canvasId, coords);
+  const { data, isLoading } = usePixelHistory(canvasId, coords, { enabled: active });
 
   const pixelHistory = data?.pixelHistory ?? [];
 

--- a/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PixelInfoTab.tsx
@@ -79,7 +79,9 @@ export default function PixelInfoTab({
 }: PixelInfoTabProps) {
   const { canvas } = useCanvasContext();
   const { adjustedCoords, containerRef, coords, zoom } = useCanvasViewContext();
-  const { data, isLoading } = usePixelHistory(canvasId, coords, { enabled: active });
+  const { data, isLoading } = usePixelHistory(canvasId, coords, {
+    enabled: active,
+  });
 
   const pixelHistory = data?.pixelHistory ?? [];
 

--- a/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
@@ -73,7 +73,7 @@ export default function PlacePixelTab({
   eventId,
   ...props
 }: PlacePixelTabProps) {
-  const { data: palette } = usePalette(eventId ?? undefined);
+  const { data: palette } = usePalette(eventId ?? undefined, { enabled: active });
   const [mainColors, partnerColors] = useMemo(
     () => (palette !== undefined ? partitionPalette(palette) : []),
     [palette],

--- a/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/PlacePixelTab.tsx
@@ -73,7 +73,9 @@ export default function PlacePixelTab({
   eventId,
   ...props
 }: PlacePixelTabProps) {
-  const { data: palette } = usePalette(eventId ?? undefined, { enabled: active });
+  const { data: palette } = usePalette(eventId ?? undefined, {
+    enabled: active,
+  });
   const [mainColors, partnerColors] = useMemo(
     () => (palette !== undefined ? partitionPalette(palette) : []),
     [palette],

--- a/packages/frontend/src/components/frames/FrameInfoPanel.tsx
+++ b/packages/frontend/src/components/frames/FrameInfoPanel.tsx
@@ -36,14 +36,16 @@ function userCanEditFrame(user: DiscordUserProfile, frame: Frame): boolean {
 }
 
 export default function FrameInfoPanel({
+  enabled = true,
   setActivePanel,
 }: {
+  enabled?: boolean;
   setActivePanel: (panel: FramePanelMode) => void;
 }) {
   return (
     <>
       <FullWidthScrollView>
-        <FrameList />
+        <FrameList enabled={enabled} />
       </FullWidthScrollView>
       <FrameInfoPanelBody setActivePanel={setActivePanel} />
     </>

--- a/packages/frontend/src/components/frames/FrameList.tsx
+++ b/packages/frontend/src/components/frames/FrameList.tsx
@@ -54,17 +54,24 @@ function selectSortedGuildFrameEntries(
     .sort(sortByOwnerGuildName);
 }
 
-export default function FrameList() {
+interface FrameListProps {
+  enabled?: boolean;
+}
+
+export default function FrameList({ enabled = true }: FrameListProps) {
   const { user } = useAuthContext();
   const { canvas } = useCanvasContext();
   const { setFrame: setSelectedFrame } = useSelectedFrameContext();
 
   const sourceImage = useCanvasImage(canvas.id);
 
-  const { data: userFramesResponse } = useUserFrames({
-    canvasId: canvas.id,
-    userId: user?.id,
-  });
+  const { data: userFramesResponse } = useUserFrames(
+    {
+      canvasId: canvas.id,
+      userId: user?.id,
+    },
+    { enabled },
+  );
   const userFrames = userFramesResponse?.data ?? [];
 
   const guildIds = Object.keys(user?.guilds ?? {});
@@ -75,6 +82,7 @@ export default function FrameList() {
     },
     {
       select: selectSortedGuildFrameEntries,
+      enabled,
     },
   );
 

--- a/packages/frontend/src/hooks/queries/useFrame.tsx
+++ b/packages/frontend/src/hooks/queries/useFrame.tsx
@@ -45,7 +45,13 @@ export function useFrameById({ frameId }: UseFrameByIdParams) {
   });
 }
 
-export function useUserFrames({ canvasId, userId }: UseUserFramesParams) {
+export function useUserFrames(
+  { canvasId, userId }: UseUserFramesParams,
+  options?: Omit<
+    UseQueryOptions<FrameRequest.UserFramesResBody>,
+    "queryKey" | "queryFn"
+  >,
+) {
   const getFrames = async (): Promise<FrameRequest.UserFramesResBody> => {
     if (!userId) return {} as FrameRequest.UserFramesResBody;
 
@@ -56,9 +62,10 @@ export function useUserFrames({ canvasId, userId }: UseUserFramesParams) {
   };
 
   return useQuery<FrameRequest.UserFramesResBody>({
+    ...options,
     queryKey: ["frame", "user", canvasId, userId],
     queryFn: getFrames,
-    enabled: Boolean(userId),
+    enabled: Boolean(userId) && (options?.enabled ?? true),
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     placeholderData: {} as FrameRequest.UserFramesResBody,

--- a/packages/frontend/src/hooks/queries/useFrame.tsx
+++ b/packages/frontend/src/hooks/queries/useFrame.tsx
@@ -52,6 +52,8 @@ export function useUserFrames(
     "queryKey" | "queryFn"
   >,
 ) {
+  const { enabled = true } = options ?? {};
+
   const getFrames = async (): Promise<FrameRequest.UserFramesResBody> => {
     if (!userId) return {} as FrameRequest.UserFramesResBody;
 
@@ -65,7 +67,7 @@ export function useUserFrames(
     ...options,
     queryKey: ["frame", "user", canvasId, userId],
     queryFn: getFrames,
-    enabled: Boolean(userId) && (options?.enabled ?? true),
+    enabled: enabled && Boolean(userId),
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     placeholderData: {} as FrameRequest.UserFramesResBody,
@@ -79,6 +81,8 @@ export function useGuildFrames<TData = FrameRequest.GuildFramesResBody>(
     "queryKey" | "queryFn"
   >,
 ) {
+  const { enabled = true } = options ?? {};
+
   const getFrames = async (): Promise<FrameRequest.GuildFramesResBody> => {
     if (!guildIds || guildIds.length === 0)
       return {} as FrameRequest.GuildFramesResBody;
@@ -103,7 +107,7 @@ export function useGuildFrames<TData = FrameRequest.GuildFramesResBody>(
     ...options,
     queryKey: ["frame", "guild", canvasId, guildIds],
     queryFn: getFrames,
-    enabled: Boolean(guildIds?.length) && (options?.enabled ?? true),
+    enabled: enabled && Boolean(guildIds?.length),
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     placeholderData: {} as FrameRequest.GuildFramesResBody,

--- a/packages/frontend/src/hooks/queries/usePalette.tsx
+++ b/packages/frontend/src/hooks/queries/usePalette.tsx
@@ -37,11 +37,12 @@ export function usePalette(
   };
 
   return useQuery<PaletteRequest.ResBody>({
+    ...useQueryOptions,
     queryKey: ["palette", eventId],
     queryFn: getPalette,
+    enabled: useQueryOptions?.enabled ?? true,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     placeholderData: [] as PaletteRequest.ResBody,
-    ...useQueryOptions,
   });
 }

--- a/packages/frontend/src/hooks/queries/usePixelHistory.tsx
+++ b/packages/frontend/src/hooks/queries/usePixelHistory.tsx
@@ -5,13 +5,17 @@ import type {
   HistoryRequest,
   Point,
 } from "@blurple-canvas-web/types";
-import { useQuery } from "@tanstack/react-query";
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config/clientConfig";
 
 export function usePixelHistory(
   canvasId: CanvasInfo["id"],
   coordinates: Point | null,
+  options?: Omit<
+    UseQueryOptions<HistoryRequest.ResBody>,
+    "queryKey" | "queryFn"
+  >,
 ) {
   const fetchHistory = async ({ signal }: { signal: AbortSignal }) => {
     if (!coordinates)
@@ -29,8 +33,10 @@ export function usePixelHistory(
   };
 
   return useQuery({
+    ...options,
     queryKey: ["pixelHistory", canvasId, coordinates],
     queryFn: fetchHistory,
+    enabled: Boolean(coordinates) && (options?.enabled ?? true),
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });


### PR DESCRIPTION
- Stuff like frames and history etc should only load when the tab is active
- Not a huge issue right now, but it's a pattern we need to apply to the moderation dashboard blacklist etc later so it's good to put it place here now