### PR TITLE
fix(frontend): simplify `<NumberField>`

### DIFF
--- a/packages/frontend/src/components/NumberField.tsx
+++ b/packages/frontend/src/components/NumberField.tsx
@@ -20,7 +20,7 @@ interface NumberFieldProps extends React.ComponentPropsWithRef<typeof Input> {
   label: React.ReactNode;
   labelProps?: React.ComponentPropsWithRef<typeof Label>;
   onValueChange?: (value: number | null) => void;
-  Wrapper?: React.FC;
+  value: number | null;
 }
 
 export default function NumberField({
@@ -31,7 +31,6 @@ export default function NumberField({
   min,
   onValueChange,
   value,
-  Wrapper = React.Fragment,
   ...props
 }: NumberFieldProps) {
   const _id = useId();

--- a/packages/frontend/src/components/NumberField.tsx
+++ b/packages/frontend/src/components/NumberField.tsx
@@ -1,118 +1,41 @@
-// Custom number field built with a native <input type="number">.
-
 import { styled } from "@mui/material/styles";
-import { ChevronDown, ChevronUp } from "lucide-react";
-import React from "react";
+import React, { useId } from "react";
 import { clamp } from "@/util";
-
-type NumberFieldValue = number | null;
-
-type NumberFieldProps = {
-  label?: React.ReactNode;
-  size?: "small" | "medium";
-  value?: NumberFieldValue;
-  min?: number;
-  max?: number;
-  disabled?: boolean;
-  onValueChange?: (value: NumberFieldValue) => void;
-};
-
-const Root = styled("div")`
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-`;
 
 const Label = styled("label")`
   color: ${({ theme }) => theme.palette.text.secondary};
+  display: block;
   font-size: 0.875rem;
-  line-height: 1.4375;
+  line-height: 1.5;
+  margin-block-end: 0.5em;
 `;
 
-const FieldRow = styled("div")<{ $size: "small" | "medium" }>(
-  ({ $size, theme }) => `
-    align-items: stretch;
-    background: var(--discord-legacy-not-quite-black);
-    border: var(--card-border);
-    border-radius: 0.5rem;
-    display: flex;
-    gap: 0;
-    min-height: ${$size === "small" ? "2.25rem" : "3.5rem"};
-    overflow: hidden;
-    transition: ${theme.transitions.create(["border-color", "box-shadow"], {
-      duration: theme.transitions.duration.shorter,
-    })};
-
-    &:focus-within {
-      border-color: var(--discord-blurple);
-      box-shadow: 0 0 0 1px var(--discord-blurple);
-    }
-  `,
-);
-
-const NativeInput = styled("input", {
-  shouldForwardProp: (prop) => prop !== "$size",
-})<{ $size: "small" | "medium" }>`
-  appearance: textfield;
-  background: transparent;
-  border: 0;
-  color: inherit;
-  flex: 1;
-  font: inherit;
-  min-width: 0;
-  outline: 0;
-  padding: ${({ $size }) =>
-    $size === "small" ? "0.375rem 0.75rem" : "0.875rem 1rem"};
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-  }
-
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    appearance: none;
-    margin: 0;
-  }
+const Input = styled("input")`
+  inline-size: 8ch;
+  padding-block: 6px;
+  padding-inline: 8px;
 `;
 
-const StepperColumn = styled("div")`
-  background: ${({ theme }) => theme.palette.action.hover};
-  border-left: var(--card-border);
-  display: flex;
-  flex-direction: column;
-`;
-
-const StepperButton = styled("button")`
-  background: transparent;
-  border: 0;
-  color: inherit;
-  cursor: pointer;
-  display: grid;
-  flex: 1;
-  min-width: 2rem;
-  place-items: center;
-
-  &:hover:not(:disabled) {
-    background: ${({ theme }) => theme.palette.action.selected};
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
-`;
+interface NumberFieldProps extends React.ComponentPropsWithRef<typeof Input> {
+  label: React.ReactNode;
+  labelProps?: React.ComponentPropsWithRef<typeof Label>;
+  onValueChange?: (value: number | null) => void;
+  Wrapper?: React.FC;
+}
 
 export default function NumberField({
+  id,
   label,
-  size = "medium",
-  value,
-  min,
+  labelProps,
   max,
-  disabled,
+  min,
   onValueChange,
+  value,
+  Wrapper = React.Fragment,
+  ...props
 }: NumberFieldProps) {
-  const inputId = React.useId();
+  const _id = useId();
+  const resolvedId = id ?? _id;
 
   function handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
     const nextValue =
@@ -121,16 +44,6 @@ export default function NumberField({
       : Number.parseInt(event.target.value, 10);
 
     onValueChange?.(Number.isNaN(nextValue) ? null : nextValue);
-  }
-
-  function changeByStep(direction: 1 | -1) {
-    const baseValue = value ?? 0;
-    const nextValue =
-      min != null || max != null ?
-        clamp(baseValue + direction, min ?? -Infinity, max ?? Infinity)
-      : baseValue + direction;
-
-    onValueChange?.(nextValue);
   }
 
   function handleBlur() {
@@ -146,40 +59,15 @@ export default function NumberField({
   }
 
   return (
-    <Root>
-      {label && <Label htmlFor={inputId}>{label}</Label>}
-      <FieldRow $size={size}>
-        <NativeInput
-          id={inputId}
-          type="number"
-          $size={size}
-          value={value ?? ""}
-          onChange={handleInputChange}
-          onBlur={handleBlur}
-          disabled={disabled}
-          min={min}
-          max={max}
-          step={1}
-        />
-        <StepperColumn>
-          <StepperButton
-            type="button"
-            aria-label="Increase"
-            onClick={() => changeByStep(1)}
-            disabled={disabled}
-          >
-            <ChevronUp size={size === "small" ? 14 : 16} />
-          </StepperButton>
-          <StepperButton
-            type="button"
-            aria-label="Decrease"
-            onClick={() => changeByStep(-1)}
-            disabled={disabled}
-          >
-            <ChevronDown size={size === "small" ? 14 : 16} />
-          </StepperButton>
-        </StepperColumn>
-      </FieldRow>
-    </Root>
+    <div>
+      <Label htmlFor={resolvedId}>{label}</Label>
+      <Input
+        id={resolvedId}
+        onBlur={handleBlur}
+        onChange={handleInputChange}
+        type="number"
+        {...props}
+      />
+    </div>
   );
 }

--- a/packages/frontend/src/components/NumberField.tsx
+++ b/packages/frontend/src/components/NumberField.tsx
@@ -16,11 +16,18 @@ const Input = styled("input")`
   padding-inline: 8px;
 `;
 
-interface NumberFieldProps extends React.ComponentPropsWithRef<typeof Input> {
+interface NumberFieldProps extends Omit<
+  React.ComponentPropsWithRef<typeof Input>,
+  "value"
+> {
+  // Overrides
+  max: number;
+  min: number;
+  value: number | null | undefined;
+  // Extensions
   label: React.ReactNode;
   labelProps?: React.ComponentPropsWithRef<typeof Label>;
   onValueChange?: (value: number | null) => void;
-  value: number | null;
 }
 
 export default function NumberField({
@@ -49,7 +56,11 @@ export default function NumberField({
     if (value === null || value === undefined) return;
     const clampedValue =
       min != null || max != null ?
-        clamp(value, min ?? -Infinity, max ?? Infinity)
+        clamp(
+          value,
+          min ?? Number.NEGATIVE_INFINITY,
+          max ?? Number.POSITIVE_INFINITY,
+        )
       : value;
 
     if (clampedValue !== value) {

--- a/packages/frontend/src/components/NumberField.tsx
+++ b/packages/frontend/src/components/NumberField.tsx
@@ -74,6 +74,8 @@ export default function NumberField({
       <Label htmlFor={resolvedId}>{label}</Label>
       <Input
         id={resolvedId}
+        max={max}
+        min={min}
         onBlur={handleBlur}
         onChange={handleInputChange}
         type="number"

--- a/packages/frontend/src/components/NumberField.tsx
+++ b/packages/frontend/src/components/NumberField.tsx
@@ -77,7 +77,7 @@ export default function NumberField({
         onBlur={handleBlur}
         onChange={handleInputChange}
         type="number"
-        value={value}
+        value={value ?? ""}
         {...props}
       />
     </div>

--- a/packages/frontend/src/components/NumberField.tsx
+++ b/packages/frontend/src/components/NumberField.tsx
@@ -32,6 +32,7 @@ interface NumberFieldProps extends Omit<
 }
 
 export default function NumberField({
+  className,
   id,
   label,
   labelProps,
@@ -70,7 +71,7 @@ export default function NumberField({
   }
 
   return (
-    <div>
+    <div className={className}>
       <Label htmlFor={resolvedId}>{label}</Label>
       <Input
         id={resolvedId}

--- a/packages/frontend/src/components/NumberField.tsx
+++ b/packages/frontend/src/components/NumberField.tsx
@@ -1,5 +1,6 @@
 import { styled } from "@mui/material/styles";
-import React, { useId } from "react";
+import type React from "react";
+import { useId } from "react";
 import { clamp } from "@/util";
 
 const Label = styled("label")`

--- a/packages/frontend/src/components/NumberField.tsx
+++ b/packages/frontend/src/components/NumberField.tsx
@@ -77,6 +77,7 @@ export default function NumberField({
         onBlur={handleBlur}
         onChange={handleInputChange}
         type="number"
+        value={value}
         {...props}
       />
     </div>

--- a/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
+++ b/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
@@ -88,6 +88,7 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
+          required
           value={displayBounds?.left ?? startX}
         />
         <NumberField
@@ -115,6 +116,7 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
+          required
           value={displayBounds?.top ?? startY}
         />
       </CoordinateInputWrapper>
@@ -146,6 +148,7 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
+          required
           value={displayBounds?.right ?? startX}
         />
         <NumberField
@@ -174,6 +177,7 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
+          required
           value={displayBounds?.bottom ?? startY}
         />
       </CoordinateInputWrapper>

--- a/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
+++ b/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
@@ -23,11 +23,12 @@ const CoordinateInputWrapper = styled("div")`
   margin-block: 1em;
 `;
 
-interface ComplexSearchBoundsSelectProps {
+interface ComplexSearchBoundsSelectProps extends React.ComponentPropsWithRef<
+  typeof CoordinateRangeWrapper
+> {
   canvas: CanvasInfo;
   selectedBounds: ViewBounds | null;
   setSelectedBounds: (bounds: ViewBounds) => void;
-  disabled: boolean;
 }
 
 function withDerivedDimensions(
@@ -45,6 +46,7 @@ export default function ComplexSearchBoundsSelect({
   selectedBounds,
   setSelectedBounds,
   disabled,
+  ...props
 }: ComplexSearchBoundsSelectProps) {
   const [startX, startY] = canvas.startCoordinates;
 
@@ -59,17 +61,16 @@ export default function ComplexSearchBoundsSelect({
     : null;
 
   return (
-    <CoordinateRangeWrapper>
+    <CoordinateRangeWrapper disabled={disabled} {...props}>
       <CoordinateInputWrapper>
         <NumberField
+          disabled={disabled}
           label={
             <>
               Left (<var>x</var>)
             </>
           }
           placeholder="x"
-          value={displayBounds?.left ?? startX}
-          min={startX}
           max={
             selectedBounds?.right != null ?
               selectedBounds.right +
@@ -77,6 +78,7 @@ export default function ComplexSearchBoundsSelect({
               COMPLEX_SEARCH_BOUNDS_MIN_SIZE.width
             : canvas.width + startX - COMPLEX_SEARCH_BOUNDS_MIN_SIZE.width
           }
+          min={startX}
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -86,17 +88,16 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
-          disabled={disabled}
+          value={displayBounds?.left ?? startX}
         />
         <NumberField
+          disabled={disabled}
           label={
             <>
               Top (<var>y</var>)
             </>
           }
           placeholder="y"
-          value={displayBounds?.top ?? startY}
-          min={startY}
           max={
             selectedBounds?.bottom != null ?
               selectedBounds.bottom +
@@ -104,6 +105,7 @@ export default function ComplexSearchBoundsSelect({
               COMPLEX_SEARCH_BOUNDS_MIN_SIZE.height
             : canvas.height + startY - COMPLEX_SEARCH_BOUNDS_MIN_SIZE.height
           }
+          min={startY}
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -113,20 +115,20 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
-          disabled={disabled}
+          value={displayBounds?.top ?? startY}
         />
       </CoordinateInputWrapper>
       <Scan size={24} />
-      {/* ^^ Potentially might make this a dropdown to select Frames in the future*/}
       <CoordinateInputWrapper>
         <NumberField
+          disabled={disabled}
           label={
             <>
               Right (<var>x</var>)
             </>
           }
           placeholder="x"
-          value={displayBounds?.right ?? startX}
+          max={canvas.width + startX - 1}
           min={
             selectedBounds?.left != null ?
               selectedBounds.left +
@@ -135,7 +137,6 @@ export default function ComplexSearchBoundsSelect({
               1
             : startX + COMPLEX_SEARCH_BOUNDS_MIN_SIZE.width
           }
-          max={canvas.width + startX - 1}
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -145,16 +146,17 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
-          disabled={disabled}
+          value={displayBounds?.right ?? startX}
         />
         <NumberField
+          disabled={disabled}
           label={
             <>
               Bottom (<var>y</var>)
             </>
           }
           placeholder="y"
-          value={displayBounds?.bottom ?? startY}
+          max={canvas.height + startY - 1}
           min={
             selectedBounds?.top != null ?
               selectedBounds.top +
@@ -163,7 +165,6 @@ export default function ComplexSearchBoundsSelect({
               1
             : startY + COMPLEX_SEARCH_BOUNDS_MIN_SIZE.height
           }
-          max={canvas.height + startY - 1}
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -173,7 +174,7 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
-          disabled={disabled}
+          value={displayBounds?.bottom ?? startY}
         />
       </CoordinateInputWrapper>
     </CoordinateRangeWrapper>

--- a/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
+++ b/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
@@ -78,6 +78,7 @@ export default function ComplexSearchBoundsSelect({
             : canvas.width + startX - COMPLEX_SEARCH_BOUNDS_MIN_SIZE.width
           }
           min={startX}
+          name="x1"
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -106,6 +107,7 @@ export default function ComplexSearchBoundsSelect({
             : canvas.height + startY - COMPLEX_SEARCH_BOUNDS_MIN_SIZE.height
           }
           min={startY}
+          name="y1"
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -138,6 +140,7 @@ export default function ComplexSearchBoundsSelect({
               1
             : startX + COMPLEX_SEARCH_BOUNDS_MIN_SIZE.width
           }
+          name="x2"
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -167,6 +170,7 @@ export default function ComplexSearchBoundsSelect({
               1
             : startY + COMPLEX_SEARCH_BOUNDS_MIN_SIZE.height
           }
+          name="y2"
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(

--- a/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
+++ b/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
@@ -70,7 +70,6 @@ export default function ComplexSearchBoundsSelect({
               Left (<var>x</var>)
             </>
           }
-          placeholder="x"
           max={
             selectedBounds?.right != null ?
               selectedBounds.right +
@@ -88,6 +87,7 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
+          placeholder="x"
           required
           value={displayBounds?.left ?? startX}
         />
@@ -98,7 +98,6 @@ export default function ComplexSearchBoundsSelect({
               Top (<var>y</var>)
             </>
           }
-          placeholder="y"
           max={
             selectedBounds?.bottom != null ?
               selectedBounds.bottom +
@@ -116,6 +115,7 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
+          placeholder="y"
           required
           value={displayBounds?.top ?? startY}
         />
@@ -129,7 +129,6 @@ export default function ComplexSearchBoundsSelect({
               Right (<var>x</var>)
             </>
           }
-          placeholder="x"
           max={canvas.width + startX - 1}
           min={
             selectedBounds?.left != null ?
@@ -148,6 +147,7 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
+          placeholder="x"
           required
           value={displayBounds?.right ?? startX}
         />
@@ -158,7 +158,6 @@ export default function ComplexSearchBoundsSelect({
               Bottom (<var>y</var>)
             </>
           }
-          placeholder="y"
           max={canvas.height + startY - 1}
           min={
             selectedBounds?.top != null ?
@@ -177,6 +176,7 @@ export default function ComplexSearchBoundsSelect({
               }),
             );
           }}
+          placeholder="y"
           required
           value={displayBounds?.bottom ?? startY}
         />

--- a/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
+++ b/packages/frontend/src/components/complex-search/ComplexSearchBoundsSelect.tsx
@@ -5,7 +5,7 @@ import NumberField from "@/components/NumberField";
 import { COMPLEX_SEARCH_BOUNDS_MIN_SIZE } from "@/constants/selectedBounds";
 import type { ViewBounds } from "@/util";
 
-const CoordinateRangeWrapper = styled("div")`
+const CoordinateRangeWrapper = styled("fieldset")`
   display: flex;
   flex-direction: row;
   gap: 0.5rem;
@@ -15,11 +15,12 @@ const CoordinateRangeWrapper = styled("div")`
   }
 `;
 const CoordinateInputWrapper = styled("div")`
+  align-items: baseline;
   display: flex;
-  flex-direction: row;
   gap: 0.5rem;
-  width: 100%;
   justify-content: center;
+  width: 100%;
+  margin-block: 1em;
 `;
 
 interface ComplexSearchBoundsSelectProps {
@@ -66,6 +67,7 @@ export default function ComplexSearchBoundsSelect({
               Left (<var>x</var>)
             </>
           }
+          placeholder="x"
           value={displayBounds?.left ?? startX}
           min={startX}
           max={
@@ -75,7 +77,6 @@ export default function ComplexSearchBoundsSelect({
               COMPLEX_SEARCH_BOUNDS_MIN_SIZE.width
             : canvas.width + startX - COMPLEX_SEARCH_BOUNDS_MIN_SIZE.width
           }
-          size="small"
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -93,6 +94,7 @@ export default function ComplexSearchBoundsSelect({
               Top (<var>y</var>)
             </>
           }
+          placeholder="y"
           value={displayBounds?.top ?? startY}
           min={startY}
           max={
@@ -102,7 +104,6 @@ export default function ComplexSearchBoundsSelect({
               COMPLEX_SEARCH_BOUNDS_MIN_SIZE.height
             : canvas.height + startY - COMPLEX_SEARCH_BOUNDS_MIN_SIZE.height
           }
-          size="small"
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -124,6 +125,7 @@ export default function ComplexSearchBoundsSelect({
               Right (<var>x</var>)
             </>
           }
+          placeholder="x"
           value={displayBounds?.right ?? startX}
           min={
             selectedBounds?.left != null ?
@@ -134,7 +136,6 @@ export default function ComplexSearchBoundsSelect({
             : startX + COMPLEX_SEARCH_BOUNDS_MIN_SIZE.width
           }
           max={canvas.width + startX - 1}
-          size="small"
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(
@@ -152,6 +153,7 @@ export default function ComplexSearchBoundsSelect({
               Bottom (<var>y</var>)
             </>
           }
+          placeholder="y"
           value={displayBounds?.bottom ?? startY}
           min={
             selectedBounds?.top != null ?
@@ -162,7 +164,6 @@ export default function ComplexSearchBoundsSelect({
             : startY + COMPLEX_SEARCH_BOUNDS_MIN_SIZE.height
           }
           max={canvas.height + startY - 1}
-          size="small"
           onValueChange={(value: number | null) => {
             if (!selectedBounds || value === null) return;
             setSelectedBounds(

--- a/packages/frontend/src/styles/core.css
+++ b/packages/frontend/src/styles/core.css
@@ -258,11 +258,23 @@
     border-radius: 8px;
     border-style: solid;
     border-width: 1px;
+  }
 
-    &:user-invalid {
-      border: 1px solid var(--discord-red);
-      background-color: oklch(from var(--discord-red) l c h / 3%);
-    }
+  input:where(
+      [type="date"],
+      [type="datetime-local"],
+      [type="email"],
+      [type="month"],
+      [type="number"],
+      [type="password"],
+      [type="search"],
+      [type="tel"],
+      [type="text"],
+      [type="url"],
+      [type="week"]
+    ):user-invalid {
+    border: 1px solid var(--discord-red);
+    background-color: oklch(from var(--discord-red) l c h / 3%);
   }
 
   /*

--- a/packages/frontend/src/styles/core.css
+++ b/packages/frontend/src/styles/core.css
@@ -244,15 +244,25 @@
     font-weight: 400;
   }
 
-  input {
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="email"],
+  input[type="month"],
+  input[type="number"],
+  input[type="password"],
+  input[type="search"],
+  input[type="tel"],
+  input[type="text"],
+  input[type="url"],
+  input[type="week"] {
     border-radius: 8px;
     border-style: solid;
     border-width: 1px;
-  }
 
-  input:user-invalid {
-    border: 1px solid var(--discord-red);
-    background-color: oklch(from var(--discord-red) l c h / 3%);
+    &:user-invalid {
+      border: 1px solid var(--discord-red);
+      background-color: oklch(from var(--discord-red) l c h / 3%);
+    }
   }
 
   /*

--- a/packages/frontend/src/styles/core.css
+++ b/packages/frontend/src/styles/core.css
@@ -225,23 +225,34 @@
     color: var(--discord-white);
     color-scheme: only dark;
     font-family: var(--font-body);
+  }
 
-    code,
-    kbd,
-    pre,
-    samp {
-      font-family: var(--font-monospace);
-    }
+  code,
+  kbd,
+  pre,
+  samp {
+    font-family: var(--font-monospace);
+  }
 
-    h1 {
-      font-stretch: 125%;
-      font-weight: 900;
-    }
+  h1 {
+    font-stretch: 125%;
+    font-weight: 900;
+  }
 
-    h2 {
-      color: oklch(from var(--discord-white) l c h / 55%);
-      font-weight: 400;
-    }
+  h2 {
+    color: oklch(from var(--discord-white) l c h / 55%);
+    font-weight: 400;
+  }
+
+  input {
+    border-radius: 8px;
+    border-style: solid;
+    border-width: 1px;
+  }
+
+  input:user-invalid {
+    border: 1px solid var(--discord-red);
+    background-color: oklch(from var(--discord-red) l c h / 3%);
   }
 
   /*


### PR DESCRIPTION
Death to MUI ✊[^foot]

<img width="1055" height="333" alt="Screenshot 2026-05-16T154031" src="https://github.com/user-attachments/assets/99ab17f4-5523-4f69-b252-752fd1b0b505" />

Could do with more custom styling, but let’s get a strong semantics/a11y foundation before we worry about perfecting cosmetics

[^foot]: Not actually and not everywhere all the time. Just on a case-by-case basis.