### PR TITLE
fix(frontend): leaderboard css

### DIFF
--- a/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
+++ b/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
@@ -26,7 +26,7 @@ const TableRow = styled("li")`
 
 const Rank = styled("div")`
   color: oklch(from currentColor l c h / 45%);
-  display: grid;
+  display: block;
   font-variant-numeric: tabular-nums;
   font-weight: 900;
   grid-row: 1 / -1;

--- a/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
+++ b/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
@@ -14,7 +14,6 @@ const TableRow = styled("li")`
   display: grid;
   grid-column: 1 / -1;
   grid-template-columns: subgrid;
-  grid-template-rows: auto auto;
   padding: 1rem;
 
   @media (hover: hover) and (pointer: fine) {
@@ -26,22 +25,12 @@ const TableRow = styled("li")`
 
 const Rank = styled("div")`
   color: oklch(from currentColor l c h / 45%);
-  display: block;
   font-variant-numeric: tabular-nums;
   font-weight: 900;
-  grid-row: 1 / -1;
-  grid-template-columns: subgrid;
   text-align: center;
   [aria-hidden="true"] {
     visibility: hidden;
   }
-`;
-
-const UsernameWrapper = styled("div")`
-  text-align: start;
-  display: grid;
-  grid-template-columns: subgrid;
-  grid-row: 1 / -1;
 `;
 
 const Username = styled("div")`
@@ -60,7 +49,6 @@ const PixelCount = styled("div")`
 
 const StyledAvatar = styled(Avatar)`
   align-self: center;
-  grid-row: 1 / -1;
 `;
 
 export interface LeaderboardRowProps {
@@ -73,10 +61,10 @@ export function LeaderboardRowSkeleton() {
       <Rank>
         <Skeleton width="2ch" />
       </Rank>
-      <UsernameWrapper>
+      <div>
         <Skeleton width="min(24ch, 100%)" />
         <Skeleton width="min(10ch, 100%)" />
-      </UsernameWrapper>
+      </div>
       <AvatarSkeleton
         size={60}
         sx={{ alignSelf: "center", gridRow: "1 / -1" }}
@@ -89,13 +77,13 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
   return (
     <TableRow>
       <Rank>{entry.rank.toLocaleString()}</Rank>
-      <UsernameWrapper>
+      <div>
         <Username>{entry.username ?? entry.userId}</Username>
         <PixelCount>
           {entry.totalPixels.toLocaleString()}&nbsp;
           {entry.totalPixels === 1 ? "pixel" : "pixels"}
         </PixelCount>
-      </UsernameWrapper>
+      </div>
       <StyledAvatar
         profilePictureUrl={entry.profilePictureUrl}
         size={60}

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -14,17 +14,14 @@ interface AvatarProps
 const StyledObject = styled("object")`
   aspect-ratio: 1;
   border-radius: calc(infinity * 1px);
-  border: oklch(from var(--discord-white) l c h / 12%) 1px solid;
-  object-fit: cover;
-  overflow: hidden;
+  border: var(--card-border);
 `;
 
 const AvatarImage = styled("img")`
-  border-radius: inherit;
-  outline: inherit;
-  outline-offset: inherit;
-  aspect-ratio: 1;
+  height: 100%;
   object-fit: cover;
+  object-position: center;
+  width: 100%;
 `;
 
 export default function Avatar({
@@ -40,24 +37,13 @@ export default function Avatar({
       role="img"
       width={size}
       height={size}
-      style={{
-        minHeight: size,
-        minWidth: size,
-        height: size,
-        width: size,
-      }}
       {...props}
     >
       <AvatarImage
         alt={`${username}’s avatar`}
         src={`https://cdn.discordapp.com/embed/avatars/${hash}.png`}
-        width="100%"
-        height="auto"
-        style={{
-          width: "100%",
-          height: "auto",
-          objectFit: "cover",
-        }}
+        width={size}
+        height={size}
       />
     </StyledObject>
   );

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -51,13 +51,12 @@ export default function Avatar({
       <AvatarImage
         alt={`${username}’s avatar`}
         src={`https://cdn.discordapp.com/embed/avatars/${hash}.png`}
-        width={size}
-        height={size}
+        width="100%"
+        height="auto"
         style={{
-          minHeight: size,
-          minWidth: size,
-          height: size,
-          width: size,
+          width: "100%",
+          height: "auto",
+          objectFit: "cover",
         }}
       />
     </StyledObject>


### PR DESCRIPTION
Fixes:
- Rank placement having a line break
- Avatar not centered

Does not break the page `/me`, that also uses Avatar.

<img height="700" alt="image" src="https://github.com/user-attachments/assets/0bb5c96b-18cf-48e8-985e-8b39fd3f7268" />
