### PR TITLE
feat(backend): caching middleware

### DIFF
--- a/packages/backend/src/middleware/cache.ts
+++ b/packages/backend/src/middleware/cache.ts
@@ -1,0 +1,37 @@
+import { styleText } from "node:util";
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import Cache from "@/app/Cache";
+
+export const middlewareCache = new Cache();
+
+function log(hit: "hit" | "miss", cacheKey: string) {
+  console.debug(
+    "Cache",
+    styleText(["bold", "green"], hit.toUpperCase()),
+    "for",
+    styleText(["italic"], cacheKey),
+  );
+}
+
+export default function cacheGets(staleTimeMs?: number): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (req.method.toUpperCase() !== "GET") next();
+
+    const key = req.originalUrl || req.url;
+
+    if (middlewareCache.has(key)) {
+      log("hit", key);
+      return res.json(middlewareCache.get(key));
+    }
+
+    log("miss", key);
+
+    const originalJson = res.json.bind(res);
+    res.json = (data) => {
+      middlewareCache.set(key, data, staleTimeMs);
+      return originalJson(data);
+    };
+
+    next();
+  };
+}

--- a/packages/backend/src/routes/api/v1/history.ts
+++ b/packages/backend/src/routes/api/v1/history.ts
@@ -1,3 +1,5 @@
+import type { Point } from "@blurple-canvas-web/types";
+import { Router } from "express";
 import cacheGets from "@/middleware/cache";
 import {
   assertLoggedIn,
@@ -16,8 +18,6 @@ import {
   deletePixelHistoryEntries,
   getPixelHistorySummary,
 } from "@/services/historyService";
-import type { Point } from "@blurple-canvas-web/types";
-import { Router } from "express";
 
 export const historyRouter = typedRouter(Router({ mergeParams: true }));
 

--- a/packages/backend/src/routes/api/v1/history.ts
+++ b/packages/backend/src/routes/api/v1/history.ts
@@ -1,5 +1,4 @@
-import type { Point } from "@blurple-canvas-web/types";
-import { Router } from "express";
+import cacheGets from "@/middleware/cache";
 import {
   assertLoggedIn,
   requireCanvasModerator,
@@ -17,12 +16,15 @@ import {
   deletePixelHistoryEntries,
   getPixelHistorySummary,
 } from "@/services/historyService";
+import type { Point } from "@blurple-canvas-web/types";
+import { Router } from "express";
 
 export const historyRouter = typedRouter(Router({ mergeParams: true }));
 
 historyRouter.get(
   "/",
   validate({ params: CanvasIdParamModel, query: PixelHistoryParamModel }),
+  cacheGets(),
   async (req, res) => {
     const startedAt = performance.now();
     const pixelHistory = await getPixelHistorySummary(

--- a/packages/backend/src/routes/api/v1/index.ts
+++ b/packages/backend/src/routes/api/v1/index.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import cacheGets from "@/middleware/cache";
 import { blocklistRouter } from "./blocklist";
 import { canvasRouter } from "./canvas";
 import { discordRouter } from "./discord";
@@ -14,7 +15,7 @@ apiV1Router.use("/blocklist", blocklistRouter);
 apiV1Router.use("/canvas", canvasRouter);
 apiV1Router.use("/discord", discordRouter);
 apiV1Router.use("/event", eventRouter);
-apiV1Router.use("/frame", frameRouter);
-apiV1Router.use("/notice", noticeRouter);
-apiV1Router.use("/palette", paletteRouter);
-apiV1Router.use("/statistics", statisticsRouter);
+apiV1Router.use("/frame", frameRouter, cacheGets(300_000));
+apiV1Router.use("/notice", noticeRouter, cacheGets(300_000));
+apiV1Router.use("/palette", paletteRouter, cacheGets(600_000));
+apiV1Router.use("/statistics", statisticsRouter, cacheGets(300_000));


### PR DESCRIPTION
> [!IMPORTANT]
> Currently missing a mechanism for cache invalidation. Also not tested.

If we accept this proposal, then the caching of Discord API requests introduced in #574 becomes redundant, because those are all `GET` requests anyway.

Stacked on #574, but primarily because that branch has the custom `Cache` class which this bit of middleware depends on.


## 🥞 Stack

1. #574
2. #575 👈