### PR TITLE
fix(frontend): locked colour accessibility

### DIFF
--- a/packages/frontend/src/components/RecheckMemberships.tsx
+++ b/packages/frontend/src/components/RecheckMemberships.tsx
@@ -3,7 +3,7 @@
 import { CircularProgress, styled } from "@mui/material";
 import { AxiosError } from "axios";
 import { type ReactNode, useEffect, useState } from "react";
-import { Button } from "@/components/button";
+import { Button, PrimitiveButton } from "@/components/button";
 import { useAuthContext } from "@/contexts";
 import { useRefreshGuildMemberships } from "@/hooks";
 
@@ -21,14 +21,9 @@ const StatusText = styled("p")`
   margin: 0;
 `;
 
-const InlineTrigger = styled("button")`
-  background: none;
-  border: 0;
-  color: inherit;
+const InlineTrigger = styled(PrimitiveButton)`
   cursor: pointer;
-  font: inherit;
-  padding: 0;
-  text-decoration: underline;
+  text-decoration-line: underline;
 
   &[aria-busy="true"] {
     cursor: progress;
@@ -46,7 +41,7 @@ const SUCCESS_TEXT_RESET_MS = 5_000;
 function getErrorText(error: unknown): string | null {
   if (!error) return null;
   if (error instanceof AxiosError && error.response?.status === 429) {
-    return "Slow down — try again in a minute.";
+    return "Slow down — try again in a minute";
   }
   return "Couldn’t reach Discord. Try again shortly.";
 }

--- a/packages/frontend/src/components/action-panel/tabs/SelectedColorInfoCard.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/SelectedColorInfoCard.tsx
@@ -9,6 +9,7 @@ import {
 
 const Wrapper = styled("div")`
   align-items: baseline;
+  border-radius: 8px;
   color: oklch(from var(--discord-white) l c h / 60%);
   display: grid;
   font-size: 1.125rem;

--- a/packages/frontend/src/components/action-panel/tabs/place/PlacePixelTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/place/PlacePixelTab.tsx
@@ -305,9 +305,9 @@ function NamedPalette({ colors, isColorDisabled, name }: NamedPaletteProps) {
           ))
         : colors.map((color) => (
             <InteractiveSwatch
-              aria-disabled={isColorDisabled?.(color) || undefined}
               aria-selected={color === selectedColor}
               key={color.code}
+              locked={isColorDisabled?.(color)}
               onClick={() => {
                 playSound();
                 setColor(color);

--- a/packages/frontend/src/components/swatch/InteractiveSwatch.tsx
+++ b/packages/frontend/src/components/swatch/InteractiveSwatch.tsx
@@ -1,6 +1,7 @@
 import { styled } from "@mui/material";
-import { Lock as LockIcon } from "lucide-react";
+import { LockKeyhole as LockIcon } from "lucide-react";
 import { PrimitiveButton } from "../button";
+import VisuallyHidden from "../VisuallyHidden";
 import { StaticSwatch } from "./StaticSwatch";
 
 const StyledSwatch = styled(StaticSwatch, {
@@ -13,7 +14,7 @@ const StyledSwatch = styled(StaticSwatch, {
   will-change: opacity; /* Chromium fumbles hover style without this 🤷 */
 
   @media (hover: hover) and (pointer: fine) {
-    &:hover:not([aria-disabled="true"], [aria-selected="true"]) {
+    &:hover:not([aria-selected="true"]) {
       opacity: 85%;
     }
   }
@@ -27,18 +28,6 @@ const StyledSwatch = styled(StaticSwatch, {
     background-clip: content-box;
     padding: 3px;
   }
-
-  &:active:not([aria-disabled="true"]) {
-    scale: 97%;
-  }
-
-  /* aria-disabled keeps the swatch clickable (so the user can select it to see
-   * why it can't be placed yet) while making it visually distinct. The lock
-   * overlay handles the disabled-state cue so we don't have to dim the swatch
-   * colors. */
-  &[aria-disabled="true"] {
-    cursor: not-allowed;
-  }
 `;
 
 const DisabledLockOverlay = styled("span")`
@@ -49,17 +38,23 @@ const DisabledLockOverlay = styled("span")`
   position: absolute;
 
   & > svg {
-    block-size: 50%;
-    inline-size: 50%;
+    block-size: 33%;
+    inline-size: 33%;
+    opacity: 60%;
   }
 `;
 
-export function InteractiveSwatch(
-  props: React.ComponentPropsWithRef<typeof StaticSwatch>,
-) {
-  const ariaDisabled = props["aria-disabled"];
-  const isDisabled = ariaDisabled === true || ariaDisabled === "true";
+interface InteractiveSwatchProps extends React.ComponentPropsWithRef<
+  typeof StaticSwatch
+> {
+  locked?: boolean;
+}
 
+export function InteractiveSwatch({
+  children,
+  locked,
+  ...props
+}: InteractiveSwatchProps) {
   return (
     <StyledSwatch
       as={PrimitiveButton}
@@ -68,9 +63,11 @@ export function InteractiveSwatch(
       type="button"
       {...props}
     >
-      {isDisabled && (
-        <DisabledLockOverlay aria-hidden>
+      {children}
+      {locked && (
+        <DisabledLockOverlay>
           <LockIcon />
+          <VisuallyHidden>Locked</VisuallyHidden>
         </DisabledLockOverlay>
       )}
     </StyledSwatch>


### PR DESCRIPTION
Updates locked colours not to be declared as `aria-disabled` to screen readers.

Still has the same colour contrast issues for swatches that are close to 50% grey. I have some ideas, but left out of scope for this PR.

<img width="920" height="2272" alt="localhost_3000_" src="https://github.com/user-attachments/assets/04bb0257-42ca-4527-bf57-63d863d7f2cf" />
