### PR TITLE
fix(backend): properly handle frame stream errors after headers are sent

### DIFF
--- a/packages/backend/src/routes/api/v1/frame.ts
+++ b/packages/backend/src/routes/api/v1/frame.ts
@@ -46,7 +46,11 @@ frameRouter.get(
     });
     stream.on("error", (err) => {
       console.error("Error streaming frame PNG:", err);
-      if (!res.headersSent) res.sendStatus(500);
+      if (res.headersSent) {
+        res.destroy(err);
+      } else {
+        res.sendStatus(500);
+      }
     });
     stream.pipe(res);
   },


### PR DESCRIPTION
Aligns it with the main canvas route