### PR TITLE
fix(swatch): update color handling for contrast support in StaticSwatch component

### DIFF
--- a/packages/frontend/src/components/swatch/StaticSwatch.tsx
+++ b/packages/frontend/src/components/swatch/StaticSwatch.tsx
@@ -13,9 +13,13 @@ const SwatchBase = styled("div")`
   position: relative;
 
   @supports not (color: contrast-color(black)) {
-    color: var(--swatch-color);
-    filter: invert(1) grayscale(1) brightness(1.3) contrast(9000);
-    mix-blend-mode: luminosity;
+    @supports (color: oklch(from red l c h)) {
+      color: oklch(from var(--swatch-color) round(1.21 - l, 1) 0 0);
+    }
+    @supports not (color: oklch(from red l c h)) {
+      color: white;
+      mix-blend-mode: difference;
+    }
   }
 
   // Makes the VisuallyHidden label smaller and positioned higher so they do not overlap the lock icon (or less chance to overlap the name label). Color is inherited from the swatch's contrast color.


### PR DESCRIPTION
We got some bug reports from people with older devices that had the swatches render full black and white. This fixes that. Verified with the same devices and browsers that were having issues that it works.

<table>
<tr>
 <td>Browser</td>
 <td>Before (live)</td>
 <td>After (local)</td>
<tr>
 <td>iOS 18.5 with Safari 18.5 (reported by nealgaming27 on Discord)</td>
 <td>
<img width="168" height="327" alt="image" src="https://github.com/user-attachments/assets/d6b100b9-1eb8-4406-be08-b9531f73b94b" />
</td>
 <td>
<img width="164" height="326" alt="image" src="https://github.com/user-attachments/assets/e08632f7-3628-45d6-9312-9963674a0c22" />
</td>
<tr>
 <td>Waterfox 6.6.13 (reported by thatbadname on Discord)</td>
 <td><img width="387" height="678" alt="image" src="https://github.com/user-attachments/assets/61877a19-a0a4-4e26-b9ff-d07ee804c3aa" /></td>
 <td>
<img width="379" height="680" alt="image" src="https://github.com/user-attachments/assets/132db0dc-9a19-4d41-9c4c-9bd6798732f5" />
</td>
</table>