### PR TITLE
refactor(frontend): streamline cooldown management

### DIFF
--- a/packages/frontend/src/components/action-panel/tabs/place/PlacePixelTab.tsx
+++ b/packages/frontend/src/components/action-panel/tabs/place/PlacePixelTab.tsx
@@ -6,19 +6,21 @@ import type {
 import { Skeleton, styled } from "@mui/material";
 import { AxiosError } from "axios";
 import type React from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import {
+  useActionPanelContext,
   useAuthContext,
   useCanvasContext,
   useCanvasViewContext,
   useSelectedColorContext,
 } from "@/contexts";
-import {
-  useCanvasCooldown,
-  usePalette,
-  usePlayCooldownExpirySound,
-  usePlaySound,
-} from "@/hooks";
+import { usePalette, usePlaySound } from "@/hooks";
 import { getUserGuildIds } from "@/util";
 import { DynamicAnchorButton } from "../../../button";
 import { InteractiveSwatch } from "../../../swatch";
@@ -120,22 +122,39 @@ export default function PlacePixelTab({
 }: PlacePixelTabProps) {
   const { user } = useAuthContext();
   const {
-    canvas: {
-      allColorsGlobal,
-      id: canvasId,
-      isLocked: readOnly,
-      webPlacingEnabled,
-    },
+    canvas: { allColorsGlobal, isLocked: readOnly, webPlacingEnabled },
   } = useCanvasContext();
-  const { data: initialCooldown } = useCanvasCooldown(canvasId, {
-    enabled: active && Boolean(user),
-  });
+  const { cooldownEndTime, setCooldownEndTime } = useActionPanelContext();
   const { signOut } = useAuthContext();
   const { coords, setCoords } = useCanvasViewContext();
-  const playCooldownExpirySound = usePlayCooldownExpirySound();
   const playPixelPlacementSound = usePlaySound("place_pixel");
-  const [cooldownSeconds, setCooldownSeconds] = useState(0);
-  const [prevTimeLeft, setPrevTimeLeft] = useState(0);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!cooldownEndTime) return () => {};
+      const id = setInterval(onStoreChange, 1000);
+      // Stop ticking once the cooldown has expired
+      const remaining = cooldownEndTime - Date.now();
+      const stopId = setTimeout(() => clearInterval(id), remaining + 500);
+      return () => {
+        clearInterval(id);
+        clearTimeout(stopId);
+      };
+    },
+    [cooldownEndTime],
+  );
+  const getSnapshot = useCallback(
+    () =>
+      cooldownEndTime ?
+        Math.max(0, Math.ceil((cooldownEndTime - Date.now()) / 1000))
+      : 0,
+    [cooldownEndTime],
+  );
+  const cooldownSeconds = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+  );
 
   const { data: palette } = usePalette(eventId ?? undefined);
 
@@ -169,15 +188,6 @@ export default function PlacePixelTab({
   );
 
   const { color: selectedColor } = useSelectedColorContext();
-
-  useEffect(
-    function syncInitialCooldown() {
-      const cooldown = initialCooldown?.cooldownEndTime;
-      if (cooldown === undefined) return;
-      setCooldownSeconds(Math.ceil(cooldown / 1000));
-    },
-    [initialCooldown?.cooldownEndTime],
-  );
 
   const inviteSlug = selectedColor?.invite;
   const hasInvite = !!inviteSlug;
@@ -217,7 +227,7 @@ export default function PlacePixelTab({
     },
     onSuccess: (data) => {
       const cooldown = data.cooldownEndTime;
-      if (cooldown) setCooldownSeconds(Math.ceil(cooldown / 1000));
+      if (cooldown) setCooldownEndTime(Date.now() + cooldown);
     },
   });
 
@@ -229,28 +239,6 @@ export default function PlacePixelTab({
     await mutateAsync();
     setCoords(null);
   };
-
-  useEffect(
-    function tickCountdown() {
-      if (cooldownSeconds > 0) {
-        const timerId = setTimeout(
-          () => setCooldownSeconds(cooldownSeconds - 1),
-          1000,
-        );
-        return () => clearTimeout(timerId);
-      }
-      setCooldownSeconds(0);
-    },
-    [cooldownSeconds],
-  );
-
-  useEffect(
-    function playJingleWhenCooldownExpires() {
-      if (prevTimeLeft > 0 && cooldownSeconds === 0) playCooldownExpirySound();
-      setPrevTimeLeft(cooldownSeconds);
-    },
-    [playCooldownExpirySound, prevTimeLeft, cooldownSeconds],
-  );
 
   return (
     <PlacePixelTabBlock {...props} active={active} ref={PlacePixelTabBlockRef}>

--- a/packages/frontend/src/contexts/ActionPanelContext.tsx
+++ b/packages/frontend/src/contexts/ActionPanelContext.tsx
@@ -6,16 +6,22 @@ import {
   type Dispatch,
   type SetStateAction,
   useContext,
+  useEffect,
   useState,
 } from "react";
+import { useCanvasCooldown, usePlayCooldownExpirySound } from "@/hooks";
+import { useAuthContext } from "./AuthProvider";
+import { useCanvasContext } from "./CanvasContext";
 
 type TabKey = "look" | "place" | "frame";
 
 interface ActionPanelContextType {
   areTabsLocked: boolean;
+  cooldownEndTime: number | null;
   currentTab: TabKey;
   isFullscreenPanelVisible: boolean;
   setAreTabsLocked: Dispatch<SetStateAction<boolean>>;
+  setCooldownEndTime: Dispatch<SetStateAction<number | null>>;
   setCurrentTab: Dispatch<SetStateAction<TabKey>>;
   setFullscreenPanelVisible: Dispatch<SetStateAction<boolean>>;
   setTempColor: Dispatch<SetStateAction<PaletteColor | null>>;
@@ -24,9 +30,11 @@ interface ActionPanelContextType {
 
 const ActionPanelContext = createContext<ActionPanelContextType>({
   areTabsLocked: false,
+  cooldownEndTime: null,
   currentTab: "place",
   isFullscreenPanelVisible: false,
   setAreTabsLocked: () => {},
+  setCooldownEndTime: () => {},
   setCurrentTab: () => {},
   setFullscreenPanelVisible: () => {},
   setTempColor: () => {},
@@ -38,16 +46,54 @@ interface ActionPanelProviderProps {
 }
 
 export const ActionPanelProvider = ({ children }: ActionPanelProviderProps) => {
+  const { canvas } = useCanvasContext();
+  const { user } = useAuthContext();
+
   const [currentTab, setCurrentTab] = useState<TabKey>("place");
   const [tempColor, setTempColor] = useState<PaletteColor | null>(null);
   const [areTabsLocked, setAreTabsLocked] = useState(false);
   const [isFullscreenPanelVisible, setFullscreenPanelVisible] = useState(false);
 
+  // Tracks the end time of the most recent pixel placement cooldown
+  const [placementCooldownEndTime, setPlacementCooldownEndTime] = useState<
+    number | null
+  >(null);
+
+  // Reset the placement cooldown during render when the canvas changes, rather
+  // than from an effect. See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [previousCanvasId, setPreviousCanvasId] = useState(canvas.id);
+  if (previousCanvasId !== canvas.id) {
+    setPreviousCanvasId(canvas.id);
+    setPlacementCooldownEndTime(null);
+  }
+
+  const { data: cooldownData } = useCanvasCooldown(canvas.id, {
+    enabled: Boolean(user),
+  });
+
+  // Effective cooldown: whichever of the API result or last placement expires later
+  const queryCooldownEndTime = cooldownData?.cooldownEndTime ?? null;
+  const cooldownEndTime =
+    Math.max(queryCooldownEndTime ?? 0, placementCooldownEndTime ?? 0) || null;
+
+  const playCooldownExpirySound = usePlayCooldownExpirySound();
+
+  // Play jingle exactly once when cooldown expires
+  useEffect(() => {
+    if (!cooldownEndTime) return;
+    const remaining = cooldownEndTime - Date.now();
+    if (remaining <= 0) return;
+    const id = setTimeout(playCooldownExpirySound, remaining);
+    return () => clearTimeout(id);
+  }, [cooldownEndTime, playCooldownExpirySound]);
+
   const value = {
     areTabsLocked,
+    cooldownEndTime,
     currentTab,
     isFullscreenPanelVisible,
     setAreTabsLocked,
+    setCooldownEndTime: setPlacementCooldownEndTime,
     setCurrentTab,
     setFullscreenPanelVisible,
     setTempColor,

--- a/packages/frontend/src/contexts/ActionPanelContext.tsx
+++ b/packages/frontend/src/contexts/ActionPanelContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { PaletteColor } from "@blurple-canvas-web/types";
+import type { Cooldown, PaletteColor } from "@blurple-canvas-web/types";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   createContext,
   type Dispatch,
@@ -21,7 +22,7 @@ interface ActionPanelContextType {
   currentTab: TabKey;
   isFullscreenPanelVisible: boolean;
   setAreTabsLocked: Dispatch<SetStateAction<boolean>>;
-  setCooldownEndTime: Dispatch<SetStateAction<number | null>>;
+  setCooldownEndTime: (value: number | null) => void;
   setCurrentTab: Dispatch<SetStateAction<TabKey>>;
   setFullscreenPanelVisible: Dispatch<SetStateAction<boolean>>;
   setTempColor: Dispatch<SetStateAction<PaletteColor | null>>;
@@ -48,33 +49,24 @@ interface ActionPanelProviderProps {
 export const ActionPanelProvider = ({ children }: ActionPanelProviderProps) => {
   const { canvas } = useCanvasContext();
   const { user } = useAuthContext();
+  const queryClient = useQueryClient();
 
   const [currentTab, setCurrentTab] = useState<TabKey>("place");
   const [tempColor, setTempColor] = useState<PaletteColor | null>(null);
   const [areTabsLocked, setAreTabsLocked] = useState(false);
   const [isFullscreenPanelVisible, setFullscreenPanelVisible] = useState(false);
 
-  // Tracks the end time of the most recent pixel placement cooldown
-  const [placementCooldownEndTime, setPlacementCooldownEndTime] = useState<
-    number | null
-  >(null);
-
-  // Reset the placement cooldown during render when the canvas changes, rather
-  // than from an effect. See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-  const [previousCanvasId, setPreviousCanvasId] = useState(canvas.id);
-  if (previousCanvasId !== canvas.id) {
-    setPreviousCanvasId(canvas.id);
-    setPlacementCooldownEndTime(null);
-  }
-
   const { data: cooldownData } = useCanvasCooldown(canvas.id, {
     enabled: Boolean(user),
   });
 
-  // Effective cooldown: whichever of the API result or last placement expires later
-  const queryCooldownEndTime = cooldownData?.cooldownEndTime ?? null;
-  const cooldownEndTime =
-    Math.max(queryCooldownEndTime ?? 0, placementCooldownEndTime ?? 0) || null;
+  const cooldownEndTime = cooldownData?.cooldownEndTime ?? null;
+
+  const setCooldownEndTime = (value: number | null) => {
+    queryClient.setQueryData<Cooldown>(["canvasCooldown", canvas.id], {
+      cooldownEndTime: value ?? undefined,
+    });
+  };
 
   const playCooldownExpirySound = usePlayCooldownExpirySound();
 
@@ -93,7 +85,7 @@ export const ActionPanelProvider = ({ children }: ActionPanelProviderProps) => {
     currentTab,
     isFullscreenPanelVisible,
     setAreTabsLocked,
-    setCooldownEndTime: setPlacementCooldownEndTime,
+    setCooldownEndTime,
     setCurrentTab,
     setFullscreenPanelVisible,
     setTempColor,

--- a/packages/frontend/src/hooks/queries/useCanvasCooldown.tsx
+++ b/packages/frontend/src/hooks/queries/useCanvasCooldown.tsx
@@ -9,14 +9,19 @@ export function useCanvasCooldown(
 ) {
   const { enabled = true } = options ?? {};
 
-  const getCanvasCooldown = async () => {
+  const getCanvasCooldown = async (): Promise<Cooldown> => {
     const { data } = await axios.get<Cooldown>(
       `${config.apiUrl}/api/v1/canvas/${encodeURIComponent(canvasId)}/cooldown/@me`,
       {
         withCredentials: true,
       },
     );
-    return data;
+    return {
+      cooldownEndTime:
+        data.cooldownEndTime == null ?
+          undefined
+        : Date.now() + data.cooldownEndTime,
+    };
   };
 
   return useQuery<Cooldown>({


### PR DESCRIPTION
This makes sure the existing cooldown is re-used like when resizing the browser from small to big (side-panel vs bottom panel), but also when collapsing the fullscreen side-panel and or switching between any of these 3 styles while a cooldown is active.

I'm sure we can do some more optimizing of this code, so if you got any feedback, please share!