### PR TITLE
fix(frontend): update mutationKey in usePlacePixelMutation to remove coords dependency

### DIFF
--- a/packages/frontend/src/components/action-panel/tabs/place/usePlacePixelMutation.ts
+++ b/packages/frontend/src/components/action-panel/tabs/place/usePlacePixelMutation.ts
@@ -19,7 +19,8 @@ export default function usePlacePixelMutation(
   const { color } = useSelectedColorContext();
 
   return useMutation<Cooldown>({
-    mutationKey: ["pixel", canvas.id, coords],
+    // TODO: figure out why coords breaks - https://github.com/project-blurple/Canvas-Web/issues/675
+    mutationKey: ["pixel", canvas.id],
     mutationFn: async () => {
       if (!coords) {
         throw new Error(


### PR DESCRIPTION
This seems to fix #675. If the server responds somewhat slow you are able to press another pixel and then mutation key changes which makes the previous cooldown show up in the background and never get added the button. I'm sure there is a better fix to #675 but I felt like this a quick fix and then later we can investigate a better more sophisticated fix for this 😅  