### PR TITLE
fix(frontend): bad leaderboard skeleton, square default avatars

### DIFF
--- a/packages/frontend/src/app/leaderboard/Leaderboard.tsx
+++ b/packages/frontend/src/app/leaderboard/Leaderboard.tsx
@@ -73,11 +73,9 @@ export default function Leaderboard() {
           ))
         : isLeaderboardEmpty ?
           <NoContentsMessage>No leaderboard found</NoContentsMessage>
-        : entries?.map(
-            (
-              entry: any, // ToDo: re-apply types
-            ) => <LeaderboardRow key={entry.userId} entry={entry} />,
-          )
+        : entries?.map((entry) => (
+            <LeaderboardRow key={entry.userId} entry={entry} />
+          ))
         }
       </List>
       <Pagination

--- a/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
+++ b/packages/frontend/src/app/leaderboard/LeaderboardRow.tsx
@@ -67,10 +67,7 @@ export function LeaderboardRowSkeleton() {
         <Skeleton width="min(24ch, 100%)" />
         <Skeleton width="min(10ch, 100%)" />
       </div>
-      <AvatarSkeleton
-        size={60}
-        sx={{ alignSelf: "center", gridRow: "1 / -1" }}
-      />
+      <AvatarSkeleton size={60} sx={{ alignSelf: "center" }} />
     </TableRow>
   );
 }

--- a/packages/frontend/src/components/Avatar.tsx
+++ b/packages/frontend/src/components/Avatar.tsx
@@ -15,6 +15,7 @@ const StyledObject = styled("object")`
   aspect-ratio: 1;
   border-radius: calc(infinity * 1px);
   border: var(--card-border);
+  overflow: clip;
 `;
 
 const AvatarImage = styled("img")`


### PR DESCRIPTION
| Status | Before | After |
|--|--|--|
| Loading | <img width="1136" height="926" alt="Screenshot 2026-05-27T132938" src="https://github.com/user-attachments/assets/1c0d2482-590c-4e77-927a-5964041f8a81" /> | <img width="1136" height="926" alt="Screenshot 2026-05-27T132949" src="https://github.com/user-attachments/assets/396ba6b0-6ef0-4dfb-b005-691e261f165d" /> |
| Success | <img width="1136" height="926" alt="Screenshot 2026-05-27T132927" src="https://github.com/user-attachments/assets/3bf60dcf-cd6c-49ec-ac45-656a01640b65" /> | <img width="1136" height="926" alt="Screenshot 2026-05-27T132922" src="https://github.com/user-attachments/assets/283c5ac3-b505-485c-8359-ad376cde6069" /> | 
