### PR TITLE
feat(frontend): redesign `<ColorChip>` with colour preview

### DIFF
--- a/packages/frontend/src/components/ColorCodeChip.tsx
+++ b/packages/frontend/src/components/ColorCodeChip.tsx
@@ -1,65 +1,35 @@
 "use client";
 
 import type { PaletteColorSummary } from "@blurple-canvas-web/types";
-import { css, styled } from "@mui/material";
+import { styled } from "@mui/material";
 import { PrimitiveButton } from "./button";
 import VisuallyHidden from "./VisuallyHidden";
 
-const StyledButton = styled(PrimitiveButton, {
-  shouldForwardProp: (prop) => prop !== "backgroundColorStr",
-})<{ backgroundColorStr?: string }>`
-  --dynamic-bg-color: var(--discord-white);
-  ${({ backgroundColorStr }) =>
-    backgroundColorStr &&
-    css`
-      --dynamic-bg-color: ${backgroundColorStr};
-    `}
-
-  background-color: oklch(
-    from var(--dynamic-bg-color) l c h /
-    ${({ backgroundColorStr }) => (backgroundColorStr ? "100%" : "12%")}
-  );
-
+const StyledButton = styled(PrimitiveButton)`
+  align-items: center;
+  background-color: oklch(1 0 0 / 12%);
+  background-color: buttonface;
   border-radius: 0.25rem;
-  cursor: pointer;
-  display: inline-block;
-  font-size: 0.9rem;
-  padding-block: 0.175em;
+  display: inline flex;
+  font-size: 85%;
+  gap: 0.25em;
+  padding-block: 0.15em;
   padding-inline: 0.5em;
   text-box-trim: trim-both;
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: oklch(
-        from var(--dynamic-bg-color) l c h /
-          ${({ backgroundColorStr }) => (backgroundColorStr ? "80%" : "20%")}
-      );
+      background-color: oklch(1 0 0 / 20%);
     }
   }
 
   &:focus-visible {
-    background-color: oklch(
-      from var(--dynamic-bg-color) l c h /
-        ${({ backgroundColorStr }) => (backgroundColorStr ? "80%" : "20%")}
-    );
+    background-color: oklch(1 0 0 / 20%);
     outline: var(--focus-outline);
   }
 
   &:active {
-    background-color: oklch(
-      from var(--dynamic-bg-color) l c h /
-        ${({ backgroundColorStr }) => (backgroundColorStr ? "94%" : "6%")}
-    );
-  }
-`;
-
-const ButtonContent = styled("code")`
-  @supports (color: color-mix(in oklab, black, black)) {
-    color: color-mix(
-      in oklab,
-      contrast-color(var(--dynamic-bg-color)) 94%,
-      var(--dynamic-bg-color)
-    );
+    background-color: oklch(1 0 0 / 6%);
   }
 `;
 
@@ -68,22 +38,22 @@ interface ColorCodeChipProps extends Omit<
   "color"
 > {
   color: PaletteColorSummary;
+  ornament?: React.ReactNode;
 }
 
-export default function ColorCodeChip({ color, ...props }: ColorCodeChipProps) {
+export default function ColorCodeChip({
+  color,
+  ornament,
+  ...props
+}: ColorCodeChipProps) {
   const { code: colorCode } = color;
 
-  const clickHandler = async () =>
-    await navigator.clipboard.writeText(colorCode);
-  const keyUpHandler = async (event: React.KeyboardEvent) => {
-    if (event.key === "Enter" || event.key === " ") {
-      await navigator.clipboard.writeText(colorCode);
-    }
-  };
+  const copyCode = async () => await navigator.clipboard.writeText(colorCode);
 
   return (
-    <StyledButton onClick={clickHandler} onKeyUp={keyUpHandler} {...props}>
-      <ButtonContent aria-hidden>{colorCode}</ButtonContent>
+    <StyledButton onClick={copyCode} {...props}>
+      {ornament}
+      <code aria-hidden>{colorCode}</code>
       <VisuallyHidden>
         Code {colorCode.split("").join("-")}. Click to copy.
       </VisuallyHidden>

--- a/packages/frontend/src/components/ColorPreview.ts
+++ b/packages/frontend/src/components/ColorPreview.ts
@@ -1,0 +1,10 @@
+import { styled } from "@mui/material";
+
+export default styled("span")`
+  background-color: currentColor;
+  display: inline-block;
+  border-radius: calc(infinity * 1px);
+  border: var(--card-border);
+  height: 1em;
+  width: 1em;
+`;

--- a/packages/frontend/src/components/complex-search/ComplexSearchColorSelect.tsx
+++ b/packages/frontend/src/components/complex-search/ComplexSearchColorSelect.tsx
@@ -8,6 +8,7 @@ import DynamicButton from "@/components/button/DynamicButton";
 import { useCanvasContext } from "@/contexts";
 import { usePalette } from "@/hooks";
 import { rgbaToCssColor } from "@/util/color";
+import ColorPreview from "../ColorPreview";
 import type { SearchFilterMode } from "./ComplexSearchTab";
 
 const SelectedColorChips = styled("div")`
@@ -18,14 +19,6 @@ const SelectedColorChips = styled("div")`
 
 const ListItem = styled("li")`
   gap: 0.5rem;
-`;
-
-const ColorPreview = styled("div")`
-  background-color: currentColor;
-  border-radius: calc(infinity * 1px);
-  border: var(--card-border);
-  height: 1em;
-  width: 1em;
 `;
 
 const ChipColorPreview = styled(ColorPreview)`

--- a/packages/frontend/src/components/complex-search/SearchUserEntry.tsx
+++ b/packages/frontend/src/components/complex-search/SearchUserEntry.tsx
@@ -8,8 +8,10 @@ import { Copy } from "lucide-react";
 import { useMemo } from "react";
 import { useCanvasContext } from "@/contexts";
 import { usePalette } from "@/hooks";
+import { rgbaToCssColor } from "@/util/color";
 import { PrimitiveButton } from "../button";
 import ColorCodeChip from "../ColorCodeChip";
+import ColorPreview from "../ColorPreview";
 import VisuallyHidden from "../VisuallyHidden";
 
 const UserWrapper = styled("ul")`
@@ -70,12 +72,18 @@ export const UserIdButton = styled(PrimitiveButton)`
 `;
 
 const ColorChipList = styled("ul")`
-  display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
   gap: 0.25rem;
   margin-block-start: 1em;
   overflow-x: auto;
+
+  li {
+    display: inline;
+  }
+  li + li {
+    margin-inline-start: 0.3em;
+  }
 `;
 
 interface SearchUserEntryProps {
@@ -104,10 +112,21 @@ function SearchUserEntry({ userId, summary, colorById }: SearchUserEntryProps) {
 
       <ColorChipList role="list" style={{ gridArea: "--color-list" }}>
         {colors.slice(0, 5).map(({ color }) => {
-          const rgb = color.rgba.slice(0, 3).join(" ");
           return (
             <li key={color.id}>
-              <ColorCodeChip color={color} backgroundColorStr={`rgb(${rgb})`} />
+              <ColorCodeChip
+                color={color}
+                ornament={
+                  <ColorPreview
+                    style={{
+                      color: rgbaToCssColor(color.rgba),
+                      fontSize: "1cap",
+                      verticalAlign: "text-bottom",
+                      translate: "0 calc(var(--border-width) * -1)",
+                    }}
+                  />
+                }
+              />
             </li>
           );
         })}


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="410" height="368" alt="Screenshot 2026-05-27T133433" src="https://github.com/user-attachments/assets/229d4006-0321-4b93-8b49-d3c86e30246f" /> | <img width="407" height="371" alt="Screenshot 2026-05-27T133459" src="https://github.com/user-attachments/assets/eba3888d-1149-4107-ba2f-8a186cc61032" /> |
| <img width="412" height="141" alt="Screenshot 2026-05-27T133544" src="https://github.com/user-attachments/assets/4d57108f-6891-4b30-ade8-776be488743e" /> | <img width="411" height="133" alt="Screenshot 2026-05-27T133538" src="https://github.com/user-attachments/assets/795dfe4c-5720-4eab-9749-bb307ede4a69" /> | 
