### PR TITLE
feat: mod dashboard overlay

### DIFF
--- a/packages/backend/src/services/historyService.overlay.test.ts
+++ b/packages/backend/src/services/historyService.overlay.test.ts
@@ -1,0 +1,111 @@
+import { prisma } from "@/client";
+import { getPixelHistorySummary } from "./historyService";
+
+vi.mock("@/client", async () => {
+  const actual = await vi.importActual<typeof import("@/client")>("@/client");
+
+  return {
+    ...actual,
+    prisma: {
+      ...actual.prisma,
+      $queryRaw: vi.fn(),
+    },
+  };
+});
+
+vi.mock("./pixelService", () => ({
+  validatePixel: vi.fn(async () => {}),
+  restorePixelsAfterHistoryModification: vi.fn(async () => {}),
+}));
+
+vi.mock("./paletteService", () => ({
+  toPaletteColorSummary: vi.fn((color) => color),
+}));
+
+vi.mock("./blocklistService", () => ({
+  addUsersToBlocklist: vi.fn(async () => {}),
+}));
+
+describe("getPixelHistorySummary overlay pixels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("omits overlay pixels when no complex filters are applied", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
+      {
+        id: 1n,
+        color_id: 2,
+        timestamp: new Date("2026-01-01T00:00:00.000Z"),
+        guild_id: null,
+        user_id: 7n,
+        color_code: "blue",
+        color_name: "Blue",
+        color_rgba: [0, 0, 255, 255],
+        color_emoji_name: null,
+        color_emoji_id: null,
+        color_global: true,
+        profile_user_id: null,
+        username: null,
+        profile_picture_url: null,
+        total_count: 1n,
+      },
+    ]);
+
+    const history = await getPixelHistorySummary({
+      canvasId: 1,
+      points: { x: 3, y: 4 },
+    });
+
+    expect(history.overlayPixels).toBeUndefined();
+    expect(vi.mocked(prisma.$queryRaw)).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes the latest color for each coordinate when filters are applied", async () => {
+    vi.mocked(prisma.$queryRaw)
+      .mockResolvedValueOnce([
+        {
+          id: 11n,
+          color_id: 3,
+          timestamp: new Date("2026-01-02T00:00:00.000Z"),
+          guild_id: null,
+          user_id: 7n,
+          color_code: "red",
+          color_name: "Red",
+          color_rgba: [234, 35, 40, 255],
+          color_emoji_name: null,
+          color_emoji_id: null,
+          color_global: false,
+          profile_user_id: null,
+          username: null,
+          profile_picture_url: null,
+          total_count: 2n,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { x: 3, y: 4, color_id: 3 },
+        { x: 5, y: 6, color_id: 2 },
+      ]);
+
+    const history = await getPixelHistorySummary(
+      {
+        canvasId: 1,
+        points: [
+          { x: 3, y: 4 },
+          { x: 5, y: 6 },
+        ],
+        userIdFilter: {
+          ids: [7n],
+          include: true,
+        },
+      },
+      false,
+    );
+
+    expect(history.overlayPixels).toEqual([
+      { x: 3, y: 4, colorId: 3 },
+      { x: 5, y: 6, colorId: 2 },
+    ]);
+    expect(vi.mocked(prisma.$queryRaw)).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/backend/src/services/historyService.ts
+++ b/packages/backend/src/services/historyService.ts
@@ -1,5 +1,6 @@
 import type {
   CanvasInfo,
+  PixelHistoryOverlayPixel,
   PixelHistoryUserSummary,
   PixelHistoryWrapper,
   Point,
@@ -112,6 +113,12 @@ interface PixelHistoryRowRawResultWithCount {
   total_count: bigint;
 }
 
+interface PixelHistoryOverlayPixelRawResult {
+  x: number;
+  y: number;
+  color_id: number;
+}
+
 function mapPixelHistoryEntry(history: PixelHistoryRow) {
   return {
     id: history.id.toString(),
@@ -128,6 +135,25 @@ function mapPixelHistoryEntry(history: PixelHistoryRow) {
         }
       : null,
   };
+}
+
+function combineWhereFragments(whereFragments: Prisma.Sql[]): Prisma.Sql {
+  if (whereFragments.length === 0) {
+    return Prisma.sql`TRUE`;
+  }
+
+  return whereFragments.length === 1 ?
+      whereFragments[0]
+    : Prisma.sql`${Prisma.join(whereFragments, " AND ")}`;
+}
+
+function hasOverlayFilters(fetchParams: GetPixelHistoryParams): boolean {
+  return Boolean(
+    fetchParams.dateRange?.from !== undefined ||
+    fetchParams.dateRange?.to !== undefined ||
+    (fetchParams.userIdFilter?.ids.length ?? 0) > 0 ||
+    (fetchParams.colorFilter?.colors.length ?? 0) > 0,
+  );
 }
 
 /**
@@ -149,17 +175,7 @@ async function getPixelHistoryRowsWithCount({
   entries: PixelHistoryRow[];
 }> {
   const whereFragments = buildPixelHistoryWhereSQL(fetchParams);
-
-  // Combine fragments with AND
-  let whereSql: Prisma.Sql;
-  if (whereFragments.length === 0) {
-    whereSql = Prisma.sql`TRUE`;
-  } else {
-    whereSql =
-      whereFragments.length === 1 ?
-        whereFragments[0]
-      : Prisma.sql`${Prisma.join(whereFragments, " AND ")}`;
-  }
+  const whereSql = combineWhereFragments(whereFragments);
 
   const take = Math.min(Math.max(size, 1), 100); // Arbitrary maximum
 
@@ -226,6 +242,30 @@ async function getPixelHistoryRowsWithCount({
     size: take,
     entries,
   };
+}
+
+async function getPixelHistoryOverlayPixels(
+  fetchParams: GetPixelHistoryParams,
+): Promise<PixelHistoryOverlayPixel[]> {
+  const whereSql = combineWhereFragments(
+    buildPixelHistoryWhereSQL(fetchParams),
+  );
+
+  const results = await prisma.$queryRaw<PixelHistoryOverlayPixelRawResult[]>`
+    SELECT DISTINCT ON (h.x, h.y)
+      h.x,
+      h.y,
+      h.color_id
+    FROM history h
+    WHERE ${whereSql}
+    ORDER BY h.x ASC, h.y ASC, h.timestamp DESC, h.id DESC
+  `;
+
+  return results.map((row) => ({
+    x: row.x,
+    y: row.y,
+    colorId: row.color_id,
+  }));
 }
 
 /**
@@ -295,12 +335,7 @@ async function getPixelHistoryUserCounts(
   fetchParams: GetPixelHistoryParams,
 ): Promise<PixelHistoryUserCountRow[]> {
   const whereFragments = buildPixelHistoryWhereSQL(fetchParams);
-
-  // Combine fragments with AND
-  const whereSql =
-    whereFragments.length === 1 ?
-      whereFragments[0]
-    : Prisma.sql`${Prisma.join(whereFragments, " AND ")}`;
+  const whereSql = combineWhereFragments(whereFragments);
 
   const results = await prisma.$queryRaw<PixelHistoryUserCountRawResult[]>`
     SELECT
@@ -347,12 +382,7 @@ async function getPixelHistoryUserColorCounts(
   fetchParams: GetPixelHistoryParams,
 ): Promise<PixelHistoryUserColorCountRow[]> {
   const whereFragments = buildPixelHistoryWhereSQL(fetchParams);
-
-  // Combine fragments with AND
-  const whereSql =
-    whereFragments.length === 1 ?
-      whereFragments[0]
-    : Prisma.sql`${Prisma.join(whereFragments, " AND ")}`;
+  const whereSql = combineWhereFragments(whereFragments);
 
   const results = await prisma.$queryRaw<PixelHistoryUserColorCountRawResult[]>`
     SELECT
@@ -467,6 +497,11 @@ export async function getPixelHistorySummary(
     size,
   });
 
+  const overlayPromise =
+    hasOverlayFilters(fetchParams) ?
+      getPixelHistoryOverlayPixels(fetchParams)
+    : Promise.resolve(null);
+
   const summaryPromise =
     includeSummary ?
       Promise.all([
@@ -475,8 +510,15 @@ export async function getPixelHistorySummary(
       ] as const)
     : Promise.resolve(null);
 
-  const [{ entries, total, page: truePage, size: trueSize }, summary] =
-    await Promise.all([pixelHistoryAndCountPromise, summaryPromise]);
+  const [
+    { entries, total, page: truePage, size: trueSize },
+    summary,
+    overlayPixels,
+  ] = await Promise.all([
+    pixelHistoryAndCountPromise,
+    summaryPromise,
+    overlayPromise,
+  ]);
 
   const users = summary ? buildPixelHistoryUsers(...summary) : undefined;
 
@@ -486,6 +528,7 @@ export async function getPixelHistorySummary(
     size: trueSize,
     entries: entries.map(mapPixelHistoryEntry),
     users,
+    overlayPixels: overlayPixels ?? undefined,
   };
 }
 
@@ -509,17 +552,7 @@ export async function deletePixelHistoryEntries(
   }
 
   const whereFragments = buildPixelHistoryWhereSQL(params);
-
-  // Combine fragments with AND
-  let whereSql: Prisma.Sql;
-  if (whereFragments.length === 0) {
-    whereSql = Prisma.sql`TRUE`;
-  } else {
-    whereSql =
-      whereFragments.length === 1 ?
-        whereFragments[0]
-      : Prisma.sql`${Prisma.join(whereFragments, " AND ")}`;
-  }
+  const whereSql = combineWhereFragments(whereFragments);
 
   const erasedAt = new Date();
 

--- a/packages/frontend/src/app/moderation/ModerationDashboard.tsx
+++ b/packages/frontend/src/app/moderation/ModerationDashboard.tsx
@@ -1,4 +1,6 @@
+import type { PixelHistoryOverlayPixel } from "@blurple-canvas-web/types";
 import styled from "@emotion/styled";
+import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useId, useState } from "react";
 import ActionPanelPrimitives from "@/components/action-panel/primitives";
 import { CanvasView } from "@/components/canvas";
@@ -23,18 +25,31 @@ const ModTabBar = styled(ActionPanelPrimitives.TabBar)`
 `;
 
 export default function ModerationDashboard() {
+  const [searchOverlayPixels, setSearchOverlayPixels] = useState<
+    PixelHistoryOverlayPixel[] | null
+  >(null);
+  const [isSearchOverlayVisible, setIsSearchOverlayVisible] = useState(false);
+
+  const actionPanel = (
+    <ModerationDashboardActionPanel
+      isSearchOverlayVisible={isSearchOverlayVisible}
+      setIsSearchOverlayVisible={setIsSearchOverlayVisible}
+      setSearchOverlayPixels={setSearchOverlayPixels}
+    />
+  );
+
   return (
     <DashboardWrapper>
       <CanvasView
-        actionPanel={<ModerationDashboardActionPanel />}
+        actionPanel={actionPanel}
         canvasLabel="Moderation dashboard"
+        searchOverlayPixels={searchOverlayPixels}
+        searchOverlayVisible={isSearchOverlayVisible}
         showInvite={false}
         showNotices={false}
         showReticle={false}
       />
-      <SlideableDrawer>
-        <ModerationDashboardActionPanel />
-      </SlideableDrawer>
+      <SlideableDrawer>{actionPanel}</SlideableDrawer>
     </DashboardWrapper>
   );
 }
@@ -43,7 +58,17 @@ type TabKey = "search" | "blocklist";
 
 const Tab = ActionPanelPrimitives.GenericTab<TabKey>;
 
-function ModerationDashboardActionPanel() {
+function ModerationDashboardActionPanel({
+  isSearchOverlayVisible,
+  setIsSearchOverlayVisible,
+  setSearchOverlayPixels,
+}: {
+  isSearchOverlayVisible: boolean;
+  setIsSearchOverlayVisible: Dispatch<SetStateAction<boolean>>;
+  setSearchOverlayPixels: Dispatch<
+    SetStateAction<PixelHistoryOverlayPixel[] | null>
+  >;
+}) {
   const [currentTab, setCurrentTab] = useState<TabKey>("search");
   const [areTabsLocked] = useState(false);
 
@@ -61,6 +86,9 @@ function ModerationDashboardActionPanel() {
     if (areTabsLocked) return;
 
     setShowSelectedBounds(!(currentTab === "search" && newTab !== "search"));
+    if (newTab !== "search") {
+      setIsSearchOverlayVisible(false);
+    }
 
     setCurrentTab(newTab);
   };
@@ -87,7 +115,13 @@ function ModerationDashboardActionPanel() {
           Blocklist
         </Tab>
       </ModTabBar>
-      <ComplexSearchTab active={currentTab === "search"} id={searchTabId} />
+      <ComplexSearchTab
+        active={currentTab === "search"}
+        id={searchTabId}
+        isSearchOverlayVisible={isSearchOverlayVisible}
+        setIsSearchOverlayVisible={setIsSearchOverlayVisible}
+        setSearchOverlayPixels={setSearchOverlayPixels}
+      />
       <BlocklistTab active={currentTab === "blocklist"} id={blocklistTabId} />
     </ActionPanelPrimitives.Root>
   );

--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -3,6 +3,7 @@
 import {
   type CanvasInfo,
   type Frame,
+  type PixelHistoryOverlayPixel,
   type PlacePixelSocket,
   type Point,
   SocketEvents,
@@ -15,6 +16,7 @@ import {
   PanelRightOpen,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import ComplexSearchOverlay from "@/components/canvas/ComplexSearchOverlay";
 import SelectedBoundsOverlay from "@/components/canvas/SelectedBoundsOverlay";
 import config from "@/config/clientConfig";
 import {
@@ -485,6 +487,8 @@ interface CanvasViewProps {
     typeof ActionPanel
   >;
   canvasLabel?: string;
+  searchOverlayPixels?: PixelHistoryOverlayPixel[] | null;
+  searchOverlayVisible?: boolean;
   showInvite?: boolean;
   showNotices?: boolean;
   showReticle?: boolean;
@@ -493,6 +497,8 @@ interface CanvasViewProps {
 export default function CanvasView({
   actionPanel,
   canvasLabel,
+  searchOverlayPixels = null,
+  searchOverlayVisible = false,
   showInvite = true,
   showNotices = true,
   showReticle = true,
@@ -1374,6 +1380,12 @@ export default function CanvasView({
             style={{ minWidth: canvas.width, minHeight: canvas.height }}
           />
         </CanvasImageWrapper>
+        <ComplexSearchOverlay
+          canvasHeight={canvas.height}
+          canvasWidth={canvas.width}
+          pixels={searchOverlayPixels}
+          visible={searchOverlayVisible}
+        />
       </div>
       {isFullscreen && isFullscreenPanelVisible && (
         <FullscreenPanelOverlay

--- a/packages/frontend/src/components/canvas/ComplexSearchOverlay.tsx
+++ b/packages/frontend/src/components/canvas/ComplexSearchOverlay.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type { PixelHistoryOverlayPixel } from "@blurple-canvas-web/types";
+import { styled } from "@mui/material";
+import { useEffect, useMemo, useRef } from "react";
+import { useCanvasContext } from "@/contexts";
+import { usePalette } from "@/hooks";
+
+const OverlayWrapper = styled("div")`
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+`;
+
+const OverlayShade = styled("svg")`
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+`;
+
+const OverlayDesaturateShade = styled("svg")`
+  inset: 0;
+  mix-blend-mode: saturation;
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+`;
+
+const OverlayCanvas = styled("canvas")`
+  inset: 0;
+  image-rendering: pixelated;
+  pointer-events: none;
+  position: absolute;
+  z-index: 1;
+`;
+
+function renderOverlayShades({
+  canvasWidth,
+  canvasHeight,
+}: {
+  canvasWidth: number;
+  canvasHeight: number;
+}) {
+  return (
+    <>
+      <OverlayShade
+        aria-hidden
+        width={canvasWidth}
+        height={canvasHeight}
+        viewBox={`0 0 ${canvasWidth} ${canvasHeight}`}
+      >
+        <rect
+          width={canvasWidth}
+          height={canvasHeight}
+          fill="#000000"
+          fillOpacity={0.75}
+        />
+      </OverlayShade>
+      <OverlayDesaturateShade
+        aria-hidden
+        width={canvasWidth}
+        height={canvasHeight}
+        viewBox={`0 0 ${canvasWidth} ${canvasHeight}`}
+      >
+        <rect
+          width={canvasWidth}
+          height={canvasHeight}
+          fill="oklch(32% 0 0deg)"
+          fillOpacity={0.5}
+        />
+      </OverlayDesaturateShade>
+    </>
+  );
+}
+
+interface ComplexSearchOverlayProps {
+  canvasHeight: number;
+  canvasWidth: number;
+  pixels: PixelHistoryOverlayPixel[] | null;
+  visible: boolean;
+}
+
+export default function ComplexSearchOverlay({
+  canvasHeight,
+  canvasWidth,
+  pixels,
+  visible,
+}: ComplexSearchOverlayProps) {
+  const { canvas } = useCanvasContext();
+  const { data: palette = [] } = usePalette(canvas.eventId ?? undefined);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const colorById = useMemo(
+    () => new Map(palette.map((color) => [color.id, color] as const)),
+    [palette],
+  );
+
+  useEffect(() => {
+    const overlayCanvas = canvasRef.current;
+    if (!overlayCanvas) return;
+
+    overlayCanvas.width = canvasWidth;
+    overlayCanvas.height = canvasHeight;
+
+    const context = overlayCanvas.getContext("2d");
+    if (!context) return;
+
+    context.clearRect(0, 0, canvasWidth, canvasHeight);
+
+    if (!visible || !pixels || pixels.length === 0) return;
+
+    for (const pixel of pixels) {
+      const color = colorById.get(pixel.colorId);
+      if (!color) continue;
+
+      const [red, green, blue, alpha] = color.rgba;
+      context.fillStyle = `rgba(${red}, ${green}, ${blue}, ${alpha / 255})`;
+      context.fillRect(pixel.x, pixel.y, 1, 1);
+    }
+  }, [canvasHeight, canvasWidth, colorById, pixels, visible]);
+
+  if (!visible || !pixels || pixels.length === 0) return null;
+
+  return (
+    <OverlayWrapper aria-hidden>
+      {renderOverlayShades({ canvasWidth, canvasHeight })}
+      <OverlayCanvas
+        ref={canvasRef}
+        width={canvasWidth}
+        height={canvasHeight}
+      />
+    </OverlayWrapper>
+  );
+}

--- a/packages/frontend/src/components/complex-search/ComplexSearchTab.tsx
+++ b/packages/frontend/src/components/complex-search/ComplexSearchTab.tsx
@@ -1,5 +1,8 @@
-import type { PixelHistoryWrapper } from "@blurple-canvas-web/types";
-import { styled } from "@mui/material";
+import type {
+  PixelHistoryOverlayPixel,
+  PixelHistoryWrapper,
+} from "@blurple-canvas-web/types";
+import { Checkbox, FormControlLabel, styled } from "@mui/material";
 import type { AxiosError } from "axios";
 import type { DateTime } from "luxon";
 import { useEffect, useState } from "react";
@@ -90,6 +93,19 @@ const EraseWrapper = styled("div")`
   gap: 0.5rem;
 `;
 
+function hasOverlayFilters(params: ComplexPixelHistoryParams | null): boolean {
+  if (!params) return false;
+
+  return Boolean(
+    params.fromDateTime ||
+    params.toDateTime ||
+    (params.includeUserIds?.length ?? 0) > 0 ||
+    (params.excludeUserIds?.length ?? 0) > 0 ||
+    (params.includeColors?.length ?? 0) > 0 ||
+    (params.excludeColors?.length ?? 0) > 0,
+  );
+}
+
 function areBoundsValid(bounds: ViewBounds | null): boolean {
   if (!bounds) return false;
 
@@ -118,9 +134,20 @@ const sortDirectionOptions: {
   { value: "ascending", label: "Ascending" },
 ];
 
+interface ComplexSearchTabProps extends React.ComponentPropsWithoutRef<
+  typeof ComplexSearchTabBlock
+> {
+  isSearchOverlayVisible: boolean;
+  setIsSearchOverlayVisible: (visible: boolean) => void;
+  setSearchOverlayPixels: (pixels: PixelHistoryOverlayPixel[] | null) => void;
+}
+
 export default function ComplexSearchTab({
+  isSearchOverlayVisible,
+  setIsSearchOverlayVisible,
+  setSearchOverlayPixels,
   ...props
-}: React.ComponentPropsWithoutRef<typeof ComplexSearchTabBlock>) {
+}: ComplexSearchTabProps) {
   const {
     setCanEdit,
     selectedBounds,
@@ -152,6 +179,9 @@ export default function ComplexSearchTab({
   const historyQuery = useComplexPixelHistory(canvas.id, searchParams);
   const historyData: PixelHistoryWrapper | null =
     searchParams === null ? null : (historyQuery.data ?? null);
+  const overlayFiltersActive = hasOverlayFilters(searchParams);
+  const showSearchOverlayToggle =
+    overlayFiltersActive && (historyData?.overlayPixels?.length ?? 0) > 0;
 
   useEffect(
     function initialiseBoundsFromCurrentView() {
@@ -183,11 +213,33 @@ export default function ComplexSearchTab({
     ],
   );
 
+  useEffect(
+    function synchroniseSearchOverlay() {
+      if (!props.active || !showSearchOverlayToggle) {
+        setSearchOverlayPixels(null);
+        setIsSearchOverlayVisible(false);
+        return;
+      }
+
+      setSearchOverlayPixels(historyData?.overlayPixels ?? null);
+      setIsSearchOverlayVisible(true);
+    },
+    [
+      historyData?.overlayPixels,
+      props.active,
+      setIsSearchOverlayVisible,
+      setSearchOverlayPixels,
+      showSearchOverlayToggle,
+    ],
+  );
+
   function handleSearchSubmit(event: React.SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!selectedBounds) return;
 
     setCanEdit(false);
+    setSearchOverlayPixels(null);
+    setIsSearchOverlayVisible(false);
 
     setSearchParams({
       point0: {
@@ -210,6 +262,8 @@ export default function ComplexSearchTab({
   }
 
   function resetResults() {
+    setSearchOverlayPixels(null);
+    setIsSearchOverlayVisible(false);
     setSearchParams(null);
   }
 
@@ -377,6 +431,20 @@ export default function ComplexSearchTab({
       {historyData && searchParams && (
         <ActionPanelTabBody>
           <EraseWrapper>
+            {showSearchOverlayToggle && (
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={isSearchOverlayVisible}
+                    onChange={(event) =>
+                      setIsSearchOverlayVisible(event.target.checked)
+                    }
+                    size="small"
+                  />
+                }
+                label="Show search overlay"
+              />
+            )}
             <ComplexSearchEraseHistory
               entriesCount={entriesCount}
               usersLength={usersLength}

--- a/packages/types/src/pixelHistory.ts
+++ b/packages/types/src/pixelHistory.ts
@@ -14,6 +14,16 @@ export const PixelHistoryRecordSchema = z.object({
 
 export type PixelHistoryRecord = z.infer<typeof PixelHistoryRecordSchema>;
 
+export const PixelHistoryOverlayPixelSchema = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+  colorId: z.number().int().nonnegative(),
+});
+
+export type PixelHistoryOverlayPixel = z.infer<
+  typeof PixelHistoryOverlayPixelSchema
+>;
+
 export const PixelHistoryUserSummarySchema = z.object({
   count: z.number().int().nonnegative(),
   colors: z.record(z.string(), z.number().int().nonnegative()),
@@ -29,6 +39,7 @@ export type PixelHistoryUserSummary = z.infer<
 export const PixelHistoryWrapperSchema = z
   .object({
     users: z.record(z.string(), PixelHistoryUserSummarySchema).optional(),
+    overlayPixels: z.array(PixelHistoryOverlayPixelSchema).optional(),
     executionDurationMs: z.number().nonnegative().optional(),
   })
   .extend(paginatedSchema(PixelHistoryRecordSchema).shape);


### PR DESCRIPTION
<img width="3010" height="1352" alt="image" src="https://github.com/user-attachments/assets/7bcc3959-2371-484c-9b1a-2dbcc0b76649" />

Added an overlay that highlights the filtered history entries returned by the complex search query in the mod dashboard