### PR TITLE
feat(backend): development auth bypass

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -16,6 +16,7 @@ FRONTEND_URL=http://localhost:3000
 NODE_ENV=development
 EXPRESS_SESSION_SECRET=
 
+BYPASS_AUTH=false # Dev only. Skips moderator/admin authorization checks.
 WEB_PLACING_ENABLED=true
 BOT_PLACING_ENABLED=true
 MAX_USER_FRAMES_ALLOWED=32 # (per canvas)

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -39,6 +39,8 @@ pnpm prisma:seed --seedings web_guild
 pnpm dev # Start the API locally with hot reloading
 ```
 
+If you need to bypass Discord moderator/admin authorization while developing locally, set `BYPASS_AUTH=true` in `.env`. This disables those checks entirely and should never be used outside development.
+
 ### Building
 
 You can transpile the API to JavaScript using:

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -30,6 +30,7 @@ const config = {
   // having a random secret would mess with persistent sessions
   expressSessionSecret:
     process.env.EXPRESS_SESSION_SECRET || "change the secret in production",
+  bypassAuth: process.env.BYPASS_AUTH === "true",
   discord: {
     clientId: requiredEnv("DISCORD_CLIENT_ID"),
     clientSecret: requiredEnv("DISCORD_CLIENT_SECRET"),
@@ -59,6 +60,35 @@ const config = {
   botApiKey: process.env.BOT_API_KEY,
   databaseUrl: requiredEnv("DATABASE_URL"),
 } as const;
+
+if (config.bypassAuth) {
+  console.warn(
+    [
+      "",
+      "######################################################################",
+      "#                                                                    #",
+      "#       __          __     _____  _   _ _____ _   _  _____           #",
+      String.raw`#       \ \        / /\   |  __ \| \ | |_   _| \ | |/ ____|          #`,
+      String.raw`#        \ \  /\  / /  \  | |__) |  \| | | | |  \| | |  __           #`,
+      String.raw`#         \ \/  \/ / /\ \ |  _  /| .   | | | | .   | | |_ |          #`,
+      String.raw`#          \  /\  / ____ \| | \ \| |\  |_| |_| |\  | |__| |          #`,
+      String.raw`#           \/  \/_/    \_\_|  \_\_| \_|_____|_| \_|\_____|          #`,
+      "#                                                                    #",
+      "#  WARNING: BYPASS AUTH IS ENABLED                                   #",
+      "#                                                                    #",
+      "#  Canvas moderator and admin authorization checks are DISABLED.     #",
+      "#  This must only be used for local development.                     #",
+      "#  Do not deploy with BYPASS_AUTH=true.                              #",
+      "#                                                                    #",
+      "######################################################################",
+      "",
+    ].join("\n"),
+  );
+
+  if (config.environment === "production") {
+    throw new Error("bypassAuth cannot be enabled in production");
+  }
+}
 
 if (!fs.existsSync(config.paths.canvases)) {
   console.debug(`Creating canvases directory at ${config.paths.canvases}`);

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -13,6 +13,25 @@ function requiredEnv(key: keyof NodeJS.ProcessEnv): string {
   return value;
 }
 
+const BYPASS_AUTH_BANNER = String.raw`
+######################################################################
+#                                                                    #
+#       __          __     _____  _   _ _____ _   _  _____           #
+#       \ \        / /\   |  __ \| \ | |_   _| \ | |/ ____|          #
+#        \ \  /\  / /  \  | |__) |  \| | | | |  \| | |  __           #
+#         \ \/  \/ / /\ \ |  _  /| .   | | | | .   | | |_ |          #
+#          \  /\  / ____ \| | \ \| |\  |_| |_| |\  | |__| |          #
+#           \/  \/_/    \_\_|  \_\_| \_|_____|_| \_|\_____|          #
+#                                                                    #
+#  WARNING: BYPASS AUTH IS ENABLED                                   #
+#                                                                    #
+#  Canvas moderator and admin authorization checks are DISABLED.     #
+#  This must only be used for local development.                     #
+#  Do not deploy with BYPASS_AUTH=true.                              #
+#                                                                    #
+######################################################################
+`.trim();
+
 const config = {
   /**
    * In development mode, secure cookies are not used for sending the profile. This is because
@@ -62,31 +81,10 @@ const config = {
 } as const;
 
 if (config.bypassAuth) {
-  console.warn(
-    [
-      "",
-      "######################################################################",
-      "#                                                                    #",
-      "#       __          __     _____  _   _ _____ _   _  _____           #",
-      String.raw`#       \ \        / /\   |  __ \| \ | |_   _| \ | |/ ____|          #`,
-      String.raw`#        \ \  /\  / /  \  | |__) |  \| | | | |  \| | |  __           #`,
-      String.raw`#         \ \/  \/ / /\ \ |  _  /| .   | | | | .   | | |_ |          #`,
-      String.raw`#          \  /\  / ____ \| | \ \| |\  |_| |_| |\  | |__| |          #`,
-      String.raw`#           \/  \/_/    \_\_|  \_\_| \_|_____|_| \_|\_____|          #`,
-      "#                                                                    #",
-      "#  WARNING: BYPASS AUTH IS ENABLED                                   #",
-      "#                                                                    #",
-      "#  Canvas moderator and admin authorization checks are DISABLED.     #",
-      "#  This must only be used for local development.                     #",
-      "#  Do not deploy with BYPASS_AUTH=true.                              #",
-      "#                                                                    #",
-      "######################################################################",
-      "",
-    ].join("\n"),
-  );
+  console.warn(`\n${BYPASS_AUTH_BANNER}\n`);
 
-  if (config.environment === "production") {
-    throw new Error("bypassAuth cannot be enabled in production");
+  if (config.environment !== "development") {
+    throw new Error("bypassAuth can only be enabled in development");
   }
 }
 

--- a/packages/backend/src/config/processEnv.d.ts
+++ b/packages/backend/src/config/processEnv.d.ts
@@ -13,6 +13,7 @@ declare namespace NodeJS {
     DISCORD_MANAGEMENT_GUILD_ID?: string;
     DISCORD_MODERATOR_ROLE_ID?: string;
 
+    BYPASS_AUTH?: string;
     BOT_PLACING_ENABLED?: string;
   }
 }

--- a/packages/backend/src/middleware/canvasAuth.ts
+++ b/packages/backend/src/middleware/canvasAuth.ts
@@ -1,5 +1,6 @@
 import type { DiscordUserProfile } from "@blurple-canvas-web/types";
 import type { NextFunction, Request, Response } from "express";
+import config from "@/config";
 import { ForbiddenError, UnauthorizedError } from "@/errors";
 import {
   isCanvasAdmin,
@@ -52,6 +53,11 @@ export async function requireCanvasModerator(
   try {
     assertLoggedIn(req);
 
+    if (config.bypassAuth) {
+      next();
+      return;
+    }
+
     const userIsCanvasModerator = await withDiscordAccessToken(
       req.session,
       isCanvasModerator,
@@ -76,6 +82,11 @@ export async function requireCanvasAdmin(
 ) {
   try {
     assertLoggedIn(req);
+
+    if (config.bypassAuth) {
+      next();
+      return;
+    }
 
     const userIsCanvasAdmin = await withDiscordAccessToken(
       req.session,


### PR DESCRIPTION
Because Discord API ratelimits are a nightmare

`BYPASS_AUTH: true`

<img width="854" height="359" alt="image" src="https://github.com/user-attachments/assets/58ade104-c58d-4e05-b583-0748a659b314" />
