### PR TITLE
fix(frontend): select only on left click when panning

### DIFF
--- a/packages/frontend/src/components/canvas/CanvasView.tsx
+++ b/packages/frontend/src/components/canvas/CanvasView.tsx
@@ -1195,7 +1195,11 @@ export default function CanvasView({
    */
   const handleCanvasClick = useCallback(
     (event: PointerEvent): void => {
-      if (!(event.currentTarget instanceof HTMLElement) || !event.isPrimary)
+      if (
+        !(event.currentTarget instanceof HTMLElement) ||
+        !event.isPrimary ||
+        event.button !== 0
+      )
         return;
       const canvas = event.currentTarget;
       // Use boundingClientRect for more accurate pixel positioning


### PR DESCRIPTION
Looks like we originally tried but it didn't work. Now you should be able to pan with all mouse buttons, but it will only select coords with left click (so you can pan with middle click without changing your selection)