### PR TITLE
feat: history endpoint ratelimit

### DIFF
--- a/packages/backend/src/middleware/canvasAuth.ts
+++ b/packages/backend/src/middleware/canvasAuth.ts
@@ -31,6 +31,17 @@ export function assertLoggedIn<R extends AnyRequest>(
   }
 }
 
+export function isLoggedIn<R extends AnyRequest>(
+  req: R,
+): req is AuthenticatedRequest<R> {
+  try {
+    assertLoggedIn(req);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function requireLoggedIn(
   req: Request,
   _res: Response,

--- a/packages/backend/src/middleware/ratelimit.ts
+++ b/packages/backend/src/middleware/ratelimit.ts
@@ -1,9 +1,10 @@
+import type { DiscordUserProfile } from "@blurple-canvas-web/types";
 import type { Request } from "express";
 import rateLimit from "express-rate-limit";
 
 // Makes sure we are rate limiting the first IP address (user's IP) in the X-Forwarded-For header.
 // If not present, use the request's IP address.
-const keyGenerator = (req: Request) => {
+const ipKeyGenerator = (req: Request) => {
   const clientIp = req.headers["x-forwarded-for"];
   if (clientIp) {
     if (typeof clientIp === "string") {
@@ -14,8 +15,18 @@ const keyGenerator = (req: Request) => {
   return req.ip ?? "";
 };
 
+// User-based key generator (assumes authenticated user has req.user.id)
+const userKeyGenerator = (req: Request) => {
+  const user = req.user as DiscordUserProfile | undefined;
+  if (user?.id) {
+    return `user-${user.id}`;
+  }
+  // Fallback to IP-based key if user is not authenticated
+  return ipKeyGenerator(req);
+};
+
 /**
- * Rate limiter for the pixel placement endpoint. Allows 3 requests per 30 seconds per IP address.
+ * Rate limiter for the pixel placement endpoint. Allows 3 requests per 30 seconds per authenticated user or IP address.
  */
 export const pixelPlacementLimiter = rateLimit({
   windowMs: 30 * 1000, // 30 seconds
@@ -23,11 +34,11 @@ export const pixelPlacementLimiter = rateLimit({
   message: "You have been rate limited",
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator,
+  keyGenerator: userKeyGenerator,
 });
 
 /**
- * Rate limiter for frame creation, modification, and deletion endpoints. Allows 10 requests per minute per IP address.
+ * Rate limiter for frame creation, modification, and deletion endpoints. Allows 10 requests per minute per authenticated user or IP address.
  */
 export const frameMutationLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
@@ -35,14 +46,14 @@ export const frameMutationLimiter = rateLimit({
   message: "You have been rate limited",
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator,
+  keyGenerator: userKeyGenerator,
 });
 
 /**
  * Rate limiter for the manual guild-membership refresh endpoint. Each call
  * bypasses our session cache and hits Discord's `/users/@me/guilds`, so we
  * tighten the budget to protect both our service and the user's Discord token.
- * Allows 3 requests per minute per IP address.
+ * Allows 3 requests per minute per authenticated user or IP address.
  */
 export const guildRefreshLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
@@ -50,5 +61,18 @@ export const guildRefreshLimiter = rateLimit({
   message: "You have been rate limited",
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator,
+  keyGenerator: userKeyGenerator,
+});
+
+/**
+ * Rate limiter for pixel history retrieval endpoints.
+ * Allows 2000 requests per 24 hours per authenticated user or IP address.
+ */
+export const historyQueryLimiter = rateLimit({
+  windowMs: 24 * 60 * 60 * 1000, // 24 hours
+  max: 2000, // 2000 requests per 24 hours
+  message: "You have been rate limited",
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: userKeyGenerator,
 });

--- a/packages/backend/src/routes/api/v1/frame.test.ts
+++ b/packages/backend/src/routes/api/v1/frame.test.ts
@@ -137,8 +137,8 @@ const sendMutationRequest = (
 
 const FRAME_MUTATION_LIMIT = 10;
 
-const getRateLimitHeaders = (ipSuffix: string) => ({
-  "Test-User-Id": "1",
+const getRateLimitHeaders = (userId: string = "1", ipSuffix: string = "1") => ({
+  "Test-User-Id": userId,
   "X-Forwarded-For": `203.0.113.${ipSuffix}`,
 });
 
@@ -260,7 +260,7 @@ describe("Frame mutation route tests", () => {
         x1: 10,
         y1: 10,
       },
-    }).set(getRateLimitHeaders("30"));
+    }).set(getRateLimitHeaders("1", "30"));
     expect(response.status).toBe(400);
     expect(response.body).toStrictEqual({
       errors: [
@@ -305,17 +305,17 @@ describe("Frame mutation route tests", () => {
             break;
         }
 
-        const ipSuffix =
-          serviceName === "create" ? "11"
-          : serviceName === "edit" ? "12"
-          : "13";
+        const userId =
+          serviceName === "create" ? "10"
+          : serviceName === "edit" ? "11"
+          : "12";
 
         for (let index = 0; index < FRAME_MUTATION_LIMIT; index++) {
           const response = await sendMutationRequest(path, {
             app,
             method,
             body,
-          }).set(getRateLimitHeaders(ipSuffix));
+          }).set(getRateLimitHeaders(userId));
           expect(response.status).toBe(successStatus);
         }
 
@@ -323,7 +323,7 @@ describe("Frame mutation route tests", () => {
           app,
           method,
           body,
-        }).set(getRateLimitHeaders(ipSuffix));
+        }).set(getRateLimitHeaders(userId));
 
         expect(blockedResponse.status).toBe(429);
         expect(blockedResponse.text).toContain("You have been rate limited");
@@ -349,7 +349,7 @@ describe("Frame mutation route tests", () => {
           app,
           method: "post",
           body: requestBody,
-        }).set(getRateLimitHeaders("21"));
+        }).set(getRateLimitHeaders("20"));
         expect(response.status).toBe(201);
       }
 
@@ -357,7 +357,7 @@ describe("Frame mutation route tests", () => {
         app,
         method: "post",
         body: requestBody,
-      }).set(getRateLimitHeaders("21"));
+      }).set(getRateLimitHeaders("20"));
       expect(blockedResponse.status).toBe(429);
 
       vi.advanceTimersByTime(60_001);
@@ -366,7 +366,7 @@ describe("Frame mutation route tests", () => {
         app,
         method: "post",
         body: requestBody,
-      }).set(getRateLimitHeaders("21"));
+      }).set(getRateLimitHeaders("20"));
 
       expect(allowedResponse.status).toBe(201);
       expect(createFrame).toHaveBeenCalledTimes(FRAME_MUTATION_LIMIT + 1);

--- a/packages/backend/src/routes/api/v1/history.test.ts
+++ b/packages/backend/src/routes/api/v1/history.test.ts
@@ -39,6 +39,8 @@ const createApp = ({ authenticated = false, moderator = false } = {}) => {
     req.session = {} as typeof req.session;
     if (authenticated) {
       req.session.discordAccessToken = "test-access-token";
+      // Ensure req.user exists for isLoggedIn check
+      req.user = req.user || ({ id: "test-user-id" } as any);
     }
     if (moderator && req.user) {
       req.user = {
@@ -58,7 +60,7 @@ describe("History route tests", () => {
     vi.clearAllMocks();
   });
 
-  it("returns pixel history for a single coordinate", async () => {
+  it("returns pixel history for a single coordinate when not logged in", async () => {
     const responseBody = {
       entries: [
         {
@@ -72,7 +74,7 @@ describe("History route tests", () => {
       ],
       total: 1,
       page: 1,
-      size: 20,
+      size: 1,
       historyIds: ["1"],
       users: {
         "1": {
@@ -105,6 +107,62 @@ describe("History route tests", () => {
           x: 2,
           y: 3,
         },
+        page: 1,
+        size: 1,
+      },
+      false,
+    );
+  });
+
+  it("returns pixel history with custom pagination when logged in", async () => {
+    const responseBody = {
+      entries: [
+        {
+          id: "1",
+          color: { id: 1, name: "Red", code: "FF00" },
+          timestamp: new Date(0).toISOString(),
+          guildId: null,
+          userId: "1",
+          userProfile: null,
+        },
+      ],
+      total: 100,
+      page: 2,
+      size: 20,
+      historyIds: ["1"],
+      users: {
+        "1": {
+          count: 1,
+          colors: {
+            "1": 1,
+          },
+          firstPlaced: new Date(0).toISOString(),
+          lastPlaced: new Date().toISOString(),
+        },
+      },
+    };
+    vi.mocked(getPixelHistorySummary).mockResolvedValueOnce(
+      responseBody as unknown as Awaited<
+        ReturnType<typeof getPixelHistorySummary>
+      >,
+    );
+
+    const app = createApp({ authenticated: true });
+    const response = await request(app)
+      .get("/api/v1/canvas/1/pixel/history?x=2&y=3&page=2&size=20")
+      .expect(200);
+
+    expect(response.body).toMatchObject(responseBody);
+    expect(getPixelHistorySummary).toHaveBeenCalledTimes(1);
+    expect(getPixelHistorySummary).toHaveBeenCalledWith(
+      {
+        canvasId: 1,
+        points: {
+          x: 2,
+          y: 3,
+        },
+        page: 2,
+        size: 20,
       },
       false,
     );

--- a/packages/backend/src/routes/api/v1/history.ts
+++ b/packages/backend/src/routes/api/v1/history.ts
@@ -10,6 +10,7 @@ import { Router } from "express";
 import type { z } from "zod";
 import {
   assertLoggedIn,
+  isLoggedIn,
   requireCanvasAdmin,
   requireCanvasModerator,
 } from "@/middleware/canvasAuth";
@@ -37,13 +38,15 @@ historyRouter.get(
       "query.size": req.query.size,
     });
 
+    const loggedIn = isLoggedIn(req);
+
     const startedAt = performance.now();
     const pixelHistory = await getPixelHistorySummary(
       {
         canvasId: req.params.canvasId,
         points: { x: req.query.x, y: req.query.y },
-        page: req.query.page,
-        size: req.query.size,
+        page: loggedIn ? req.query.page : 1,
+        size: loggedIn ? req.query.size : 1,
       },
       false,
     );

--- a/packages/backend/src/routes/api/v1/history.ts
+++ b/packages/backend/src/routes/api/v1/history.ts
@@ -14,6 +14,7 @@ import {
   requireCanvasAdmin,
   requireCanvasModerator,
 } from "@/middleware/canvasAuth";
+import { historyQueryLimiter } from "@/middleware/ratelimit";
 import { typedRouter } from "@/middleware/typedRouter";
 import { validate } from "@/middleware/validate";
 import { audit } from "@/services/auditLogService";
@@ -28,6 +29,7 @@ export const historyRouter = typedRouter(Router({ mergeParams: true }));
 
 historyRouter.get(
   "/",
+  historyQueryLimiter,
   validate({ params: CanvasIdParamModel, query: PixelHistoryParamModel }),
   async (req, res) => {
     addSpanAttributes(req, {

--- a/packages/frontend/src/hooks/queries/usePixelHistory.tsx
+++ b/packages/frontend/src/hooks/queries/usePixelHistory.tsx
@@ -48,6 +48,7 @@ export function usePixelHistory(
           size: params.size ?? 20,
         },
         signal,
+        withCredentials: true,
       },
     );
 


### PR DESCRIPTION
- 2000/day per auth'd user or IP
  - all the ratelimits are updated to ratelimit by authenticated user first, otherwise by IP second
    - (all the endpoints that already use ratelimits are authenticated endpoints anyways)
- limited results when not auth'd