### PR TITLE
feat(backend): more stats views

### DIFF
--- a/packages/backend/prisma/core/migrations/20260621000000_add_color_leaderboard_views/migration.sql
+++ b/packages/backend/prisma/core/migrations/20260621000000_add_color_leaderboard_views/migration.sql
@@ -3,13 +3,13 @@ SELECT
   history.user_id,
   history.canvas_id,
   history.color_id,
-  count(*) AS total_pixels,
+  COUNT(*)::integer AS total_pixels,
   rank() OVER (
     PARTITION BY
       history.canvas_id,
       history.color_id
     ORDER BY
-      (count(*)) DESC
+      (COUNT(*)::integer) DESC
   ) AS rank
 FROM
   history
@@ -31,14 +31,14 @@ SELECT
   history.canvas_id,
   frame.id as frame_id,
   history.color_id,
-  count(*) AS total_pixels,
+  COUNT(*)::integer AS total_pixels,
   rank() OVER (
     PARTITION BY
       history.canvas_id,
       frame.id,
       history.color_id
     ORDER BY
-      (count(*)) DESC
+      (COUNT(*)::integer) DESC
   ) AS rank
 FROM
   history
@@ -66,13 +66,13 @@ SELECT
   history.user_id,
   history.canvas_id,
   frame.id AS frame_id,
-  count(*)::integer AS total_pixels,
+  COUNT(*)::integer AS total_pixels,
   rank() OVER (
     PARTITION BY
       history.canvas_id,
       frame.id
     ORDER BY
-      count(*) DESC
+      COUNT(*)::integer DESC
   ) AS rank
 FROM
   history

--- a/packages/backend/prisma/core/migrations/20260621000000_add_color_leaderboard_views/migration.sql
+++ b/packages/backend/prisma/core/migrations/20260621000000_add_color_leaderboard_views/migration.sql
@@ -1,0 +1,66 @@
+DROP VIEW IF EXISTS color_leaderboard;
+
+DROP VIEW IF EXISTS color_leaderboard_frame;
+
+CREATE VIEW color_leaderboard AS
+SELECT
+  history.user_id,
+  history.canvas_id,
+  history.color_id,
+  count(*) AS total_pixels,
+  rank() OVER (
+    PARTITION BY
+      history.canvas_id,
+      history.color_id
+    ORDER BY
+      (count(*)) DESC
+  ) AS rank
+FROM
+  history
+WHERE
+  history.user_id NOT IN (
+    SELECT
+      user_id
+    FROM
+      blacklist
+  )
+GROUP BY
+  history.user_id,
+  history.canvas_id,
+  history.color_id;
+
+CREATE VIEW color_leaderboard_frame AS
+SELECT
+  history.user_id,
+  history.canvas_id,
+  frame.id as frame_id,
+  history.color_id,
+  count(*) AS total_pixels,
+  rank() OVER (
+    PARTITION BY
+      history.canvas_id,
+      frame.id,
+      history.color_id
+    ORDER BY
+      (count(*)) DESC
+  ) AS rank
+FROM
+  history
+INNER JOIN frame ON
+  history.canvas_id = frame.canvas_id
+  AND history.x >= frame.x_0
+  AND history.x <= frame.x_1
+  AND history.y >= frame.y_0
+  AND history.y <= frame.y_1
+WHERE
+  history.user_id NOT IN (
+    SELECT
+      user_id
+    FROM
+      blacklist
+  )
+GROUP BY
+  history.user_id,
+  history.canvas_id,
+  frame.id,
+  history.color_id;

--- a/packages/backend/prisma/core/migrations/20260621000000_add_color_leaderboard_views/migration.sql
+++ b/packages/backend/prisma/core/migrations/20260621000000_add_color_leaderboard_views/migration.sql
@@ -2,6 +2,8 @@ DROP VIEW IF EXISTS color_leaderboard;
 
 DROP VIEW IF EXISTS color_leaderboard_frame;
 
+DROP VIEW IF EXISTS leaderboard_frame;
+
 CREATE VIEW color_leaderboard AS
 SELECT
   history.user_id,
@@ -64,3 +66,23 @@ GROUP BY
   history.canvas_id,
   frame.id,
   history.color_id;
+
+CREATE VIEW leaderboard_frame AS
+SELECT
+  color_leaderboard_frame.user_id,
+  color_leaderboard_frame.canvas_id,
+  color_leaderboard_frame.frame_id,
+  (sum(color_leaderboard_frame.total_pixels))::integer AS total_pixels,
+  rank() OVER (
+    PARTITION BY
+      color_leaderboard_frame.canvas_id,
+      color_leaderboard_frame.frame_id
+    ORDER BY
+      (sum(color_leaderboard_frame.total_pixels)) DESC
+  ) AS rank
+FROM
+  color_leaderboard_frame
+GROUP BY
+  color_leaderboard_frame.user_id,
+  color_leaderboard_frame.canvas_id,
+  color_leaderboard_frame.frame_id;

--- a/packages/backend/prisma/core/migrations/20260621000000_add_color_leaderboard_views/migration.sql
+++ b/packages/backend/prisma/core/migrations/20260621000000_add_color_leaderboard_views/migration.sql
@@ -1,9 +1,3 @@
-DROP VIEW IF EXISTS color_leaderboard;
-
-DROP VIEW IF EXISTS color_leaderboard_frame;
-
-DROP VIEW IF EXISTS leaderboard_frame;
-
 CREATE VIEW color_leaderboard AS
 SELECT
   history.user_id,
@@ -69,20 +63,30 @@ GROUP BY
 
 CREATE VIEW leaderboard_frame AS
 SELECT
-  color_leaderboard_frame.user_id,
-  color_leaderboard_frame.canvas_id,
-  color_leaderboard_frame.frame_id,
-  (sum(color_leaderboard_frame.total_pixels))::integer AS total_pixels,
+  history.user_id,
+  history.canvas_id,
+  frame.id AS frame_id,
+  count(*)::integer AS total_pixels,
   rank() OVER (
     PARTITION BY
-      color_leaderboard_frame.canvas_id,
-      color_leaderboard_frame.frame_id
+      history.canvas_id,
+      frame.id
     ORDER BY
-      (sum(color_leaderboard_frame.total_pixels)) DESC
+      count(*) DESC
   ) AS rank
 FROM
-  color_leaderboard_frame
+  history
+INNER JOIN frame ON
+  history.canvas_id = frame.canvas_id
+  AND history.x >= frame.x_0
+  AND history.x <= frame.x_1
+  AND history.y >= frame.y_0
+  AND history.y <= frame.y_1
+WHERE
+  history.user_id NOT IN (
+    SELECT user_id FROM blacklist
+  )
 GROUP BY
-  color_leaderboard_frame.user_id,
-  color_leaderboard_frame.canvas_id,
-  color_leaderboard_frame.frame_id;
+  history.user_id,
+  history.canvas_id,
+  frame.id;

--- a/packages/backend/prisma/core/migrations/20260621100000_add_frame_stats_views/migration.sql
+++ b/packages/backend/prisma/core/migrations/20260621100000_add_frame_stats_views/migration.sql
@@ -28,7 +28,7 @@ CREATE VIEW canvas_colors AS
 SELECT
   history.canvas_id,
   history.color_id,
-  count(*) AS count
+  COUNT(*)::integer AS count
 FROM
   history
 WHERE
@@ -50,7 +50,7 @@ SELECT
   frame.id AS frame_id,
   history.canvas_id,
   history.color_id,
-  count(*) AS count
+  COUNT(*)::integer AS count
 FROM
   history
 INNER JOIN frame ON

--- a/packages/backend/prisma/core/migrations/20260621100000_add_frame_stats_views/migration.sql
+++ b/packages/backend/prisma/core/migrations/20260621100000_add_frame_stats_views/migration.sql
@@ -1,0 +1,25 @@
+CREATE VIEW frame_stats AS
+SELECT
+  frame.id AS frame_id,
+  frame.canvas_id,
+  COUNT(DISTINCT history.user_id)::integer AS total_users,
+  COUNT(*)::integer AS total_pixels,
+  MAX(history.timestamp) AS last_placed_at
+FROM
+  history
+INNER JOIN frame ON
+  history.canvas_id = frame.canvas_id
+  AND history.x >= frame.x_0
+  AND history.x <= frame.x_1
+  AND history.y >= frame.y_0
+  AND history.y <= frame.y_1
+WHERE
+  history.user_id NOT IN (
+    SELECT
+      user_id
+    FROM
+      blacklist
+  )
+GROUP BY
+  frame.id,
+  frame.canvas_id;

--- a/packages/backend/prisma/core/migrations/20260621100000_add_frame_stats_views/migration.sql
+++ b/packages/backend/prisma/core/migrations/20260621100000_add_frame_stats_views/migration.sql
@@ -23,3 +23,54 @@ WHERE
 GROUP BY
   frame.id,
   frame.canvas_id;
+
+CREATE VIEW canvas_colors AS
+SELECT
+  history.canvas_id,
+  history.color_id,
+  count(*) AS total_pixels
+FROM
+  history
+WHERE
+  history.user_id NOT IN (
+    SELECT
+      user_id
+    FROM
+      blacklist
+  )
+GROUP BY
+  history.canvas_id,
+  history.color_id
+ORDER BY
+  history.canvas_id,
+  total_pixels DESC
+
+CREATE VIEW frame_colors AS
+SELECT
+  frame.id AS frame_id,
+  history.canvas_id,
+  history.color_id,
+  count(*) AS total_pixels
+FROM
+  history
+INNER JOIN frame ON
+  history.canvas_id = frame.canvas_id
+  AND history.x >= frame.x_0
+  AND history.x <= frame.x_1
+  AND history.y >= frame.y_0
+  AND history.y <= frame.y_1
+WHERE
+  history.user_id NOT IN (
+    SELECT
+      user_id
+    FROM
+      blacklist
+  )
+GROUP BY
+  frame.id,
+  history.canvas_id,
+  history.color_id
+ORDER BY
+  history.canvas_id,
+  frame.id,
+  total_pixels DESC;

--- a/packages/backend/prisma/core/migrations/20260621100000_add_frame_stats_views/migration.sql
+++ b/packages/backend/prisma/core/migrations/20260621100000_add_frame_stats_views/migration.sql
@@ -28,7 +28,7 @@ CREATE VIEW canvas_colors AS
 SELECT
   history.canvas_id,
   history.color_id,
-  count(*) AS total_pixels
+  count(*) AS count
 FROM
   history
 WHERE
@@ -43,14 +43,14 @@ GROUP BY
   history.color_id
 ORDER BY
   history.canvas_id,
-  total_pixels DESC
+  count DESC;
 
 CREATE VIEW frame_colors AS
 SELECT
   frame.id AS frame_id,
   history.canvas_id,
   history.color_id,
-  count(*) AS total_pixels
+  count(*) AS count
 FROM
   history
 INNER JOIN frame ON
@@ -73,4 +73,4 @@ GROUP BY
 ORDER BY
   history.canvas_id,
   frame.id,
-  total_pixels DESC;
+  count DESC;

--- a/packages/backend/prisma/core/schema.prisma
+++ b/packages/backend/prisma/core/schema.prisma
@@ -52,6 +52,8 @@ model canvas {
   colorLeaderboards        color_leaderboard[]
   leaderboardFrames        leaderboard_frame[]
   frameStats               frame_stats[]
+  canvasColors             canvas_colors[]
+  frameColors              frame_colors[]
 }
 
 model color {
@@ -69,6 +71,8 @@ model color {
   participations         participation[]
   colorLeaderboardFrames color_leaderboard_frame[]
   colorLeaderboards      color_leaderboard[]
+  canvasColors           canvas_colors[]
+  frameColors            frame_colors[]
 }
 
 model cooldown {
@@ -126,6 +130,7 @@ model frame {
   colorLeaderboardFrames color_leaderboard_frame[]
   leaderboardFrames      leaderboard_frame[]
   frameStats             frame_stats?
+  frameColors            frame_colors[]
 }
 
 model guild {
@@ -418,9 +423,27 @@ view frame_stats {
   @@unique([frame_id])
 }
 
-// todo
-// view canvas_colors {canvas_id Int, color_id Int, count Int}
-// view frame_colors {frame_id String, color_id Int, count Int}
+view canvas_colors {
+  canvas_id Int
+  canvas    canvas @relation(fields: [canvas_id], references: [id])
+  color_id  Int
+  color     color  @relation(fields: [color_id], references: [id])
+  count     Int
+
+  @@unique([canvas_id, color_id])
+}
+
+view frame_colors {
+  frame_id  String
+  frame     frame  @relation(fields: [frame_id], references: [id])
+  canvas_id Int
+  canvas    canvas @relation(fields: [canvas_id], references: [id])
+  color_id  Int
+  color     color  @relation(fields: [color_id], references: [id])
+  count     Int
+
+  @@unique([frame_id, color_id])
+}
 
 view history_snapshot_windows {
   canvas_id     Int

--- a/packages/backend/prisma/core/schema.prisma
+++ b/packages/backend/prisma/core/schema.prisma
@@ -50,6 +50,7 @@ model canvas {
   history_snapshot_windows history_snapshot_windows[]
   colorLeaderboardFrames   color_leaderboard_frame[]
   colorLeaderboards        color_leaderboard[]
+  leaderboardFrames        leaderboard_frame[]
 }
 
 model color {
@@ -90,6 +91,7 @@ model discord_user_profile {
   user                   user                      @relation(fields: [user_id], references: [id])
   colorLeaderboardFrames color_leaderboard_frame[]
   colorLeaderboards      color_leaderboard[]
+  leaderboardFrames      leaderboard_frame[]
 }
 
 model discord_guild_record {
@@ -121,6 +123,7 @@ model frame {
   y_1                    Int
   style_id               Int?
   colorLeaderboardFrames color_leaderboard_frame[]
+  leaderboardFrames      leaderboard_frame[]
 }
 
 model guild {
@@ -206,6 +209,7 @@ model user {
   audit_logs             audit_log[]
   colorLeaderboardFrames color_leaderboard_frame[]
   colorLeaderboards      color_leaderboard[]
+  leaderboardFrames      leaderboard_frame[]
 }
 
 model session {
@@ -301,6 +305,20 @@ view leaderboard_guild {
   rank                 Int
 
   @@unique([user_id, canvas_id, guild_id])
+}
+
+view leaderboard_frame {
+  user_id              BigInt
+  user                 user                  @relation(fields: [user_id], references: [id])
+  canvas_id            Int
+  canvas               canvas                @relation(fields: [canvas_id], references: [id])
+  frame_id             String
+  frame                frame                 @relation(fields: [frame_id], references: [id])
+  discord_user_profile discord_user_profile? @relation(fields: [user_id], references: [user_id])
+  total_pixels         Int
+  rank                 Int
+
+  @@unique([user_id, canvas_id, frame_id])
 }
 
 view color_leaderboard {

--- a/packages/backend/prisma/core/schema.prisma
+++ b/packages/backend/prisma/core/schema.prisma
@@ -48,21 +48,25 @@ model canvas {
   notices                  notice[]
   canvas_stats             canvas_stats?
   history_snapshot_windows history_snapshot_windows[]
+  colorLeaderboardFrames   color_leaderboard_frame[]
+  colorLeaderboards        color_leaderboard[]
 }
 
 model color {
-  id             Int             @id @default(autoincrement())
-  code           String
-  emoji_name     String?
-  emoji_id       BigInt?
-  global         Boolean         @default(true)
-  name           String
-  rgba           Int[]
-  pixels         pixel[]
-  history        history[]
-  user_stats     user_stats[]
-  guild_stats    guild_stats[]
-  participations participation[]
+  id                     Int                       @id @default(autoincrement())
+  code                   String
+  emoji_name             String?
+  emoji_id               BigInt?
+  global                 Boolean                   @default(true)
+  name                   String
+  rgba                   Int[]
+  pixels                 pixel[]
+  history                history[]
+  user_stats             user_stats[]
+  guild_stats            guild_stats[]
+  participations         participation[]
+  colorLeaderboardFrames color_leaderboard_frame[]
+  colorLeaderboards      color_leaderboard[]
 }
 
 model cooldown {
@@ -77,13 +81,15 @@ model cooldown {
 }
 
 model discord_user_profile {
-  user_id             BigInt              @id
-  username            String
-  profile_picture_url String
-  history             history[]
-  leaderboard_guild   leaderboard_guild[]
-  leaderboard         leaderboard[]
-  user                user                @relation(fields: [user_id], references: [id])
+  user_id                BigInt                    @id
+  username               String
+  profile_picture_url    String
+  history                history[]
+  leaderboard_guild      leaderboard_guild[]
+  leaderboard            leaderboard[]
+  user                   user                      @relation(fields: [user_id], references: [id])
+  colorLeaderboardFrames color_leaderboard_frame[]
+  colorLeaderboards      color_leaderboard[]
 }
 
 model discord_guild_record {
@@ -102,18 +108,19 @@ model event {
 }
 
 model frame {
-  id             String  @id
-  canvas_id      Int
-  canvas         canvas  @relation(fields: [canvas_id], references: [id])
+  id                     String                    @id
+  canvas_id              Int
+  canvas                 canvas                    @relation(fields: [canvas_id], references: [id])
   // There is a database check that requires one of them to be set
-  owner_user_id  BigInt?
-  owner_guild_id BigInt?
-  name           String
-  x_0            Int
-  x_1            Int
-  y_0            Int
-  y_1            Int
-  style_id       Int?
+  owner_user_id          BigInt?
+  owner_guild_id         BigInt?
+  name                   String
+  x_0                    Int
+  x_1                    Int
+  y_0                    Int
+  y_1                    Int
+  style_id               Int?
+  colorLeaderboardFrames color_leaderboard_frame[]
 }
 
 model guild {
@@ -185,18 +192,20 @@ model pixel {
 }
 
 model user {
-  id                   BigInt                @id
-  current_canvas_id    Int?
-  skip_confirm         Boolean               @default(false)
-  cooldown_remind      Boolean               @default(false)
-  blacklist            blacklist?
-  cooldowns            cooldown[]
-  history              history[]
-  user_stats           user_stats[]
-  leaderboard          leaderboard[]
-  leaderboard_guild    leaderboard_guild[]
-  discord_user_profile discord_user_profile?
-  audit_logs           audit_log[]
+  id                     BigInt                    @id
+  current_canvas_id      Int?
+  skip_confirm           Boolean                   @default(false)
+  cooldown_remind        Boolean                   @default(false)
+  blacklist              blacklist?
+  cooldowns              cooldown[]
+  history                history[]
+  user_stats             user_stats[]
+  leaderboard            leaderboard[]
+  leaderboard_guild      leaderboard_guild[]
+  discord_user_profile   discord_user_profile?
+  audit_logs             audit_log[]
+  colorLeaderboardFrames color_leaderboard_frame[]
+  colorLeaderboards      color_leaderboard[]
 }
 
 model session {
@@ -292,6 +301,36 @@ view leaderboard_guild {
   rank                 Int
 
   @@unique([user_id, canvas_id, guild_id])
+}
+
+view color_leaderboard {
+  user_id              BigInt
+  user                 user                  @relation(fields: [user_id], references: [id])
+  canvas_id            Int
+  canvas               canvas                @relation(fields: [canvas_id], references: [id])
+  color_id             Int
+  color                color                 @relation(fields: [color_id], references: [id])
+  discord_user_profile discord_user_profile? @relation(fields: [user_id], references: [user_id])
+  total_pixels         Int
+  rank                 Int
+
+  @@unique([user_id, canvas_id, color_id])
+}
+
+view color_leaderboard_frame {
+  user_id              BigInt
+  user                 user                  @relation(fields: [user_id], references: [id])
+  canvas_id            Int
+  canvas               canvas                @relation(fields: [canvas_id], references: [id])
+  frame_id             String
+  frame                frame                 @relation(fields: [frame_id], references: [id])
+  color_id             Int
+  color                color                 @relation(fields: [color_id], references: [id])
+  discord_user_profile discord_user_profile? @relation(fields: [user_id], references: [user_id])
+  total_pixels         Int
+  rank                 Int
+
+  @@unique([user_id, canvas_id, frame_id, color_id])
 }
 
 view color_place_frequency {

--- a/packages/backend/prisma/core/schema.prisma
+++ b/packages/backend/prisma/core/schema.prisma
@@ -51,6 +51,7 @@ model canvas {
   colorLeaderboardFrames   color_leaderboard_frame[]
   colorLeaderboards        color_leaderboard[]
   leaderboardFrames        leaderboard_frame[]
+  frameStats               frame_stats[]
 }
 
 model color {
@@ -124,6 +125,7 @@ model frame {
   style_id               Int?
   colorLeaderboardFrames color_leaderboard_frame[]
   leaderboardFrames      leaderboard_frame[]
+  frameStats             frame_stats?
 }
 
 model guild {
@@ -403,6 +405,22 @@ view event_stats {
 
   @@unique([event_id])
 }
+
+view frame_stats {
+  frame_id       String
+  frame          frame    @relation(fields: [frame_id], references: [id])
+  canvas_id      Int
+  canvas         canvas   @relation(fields: [canvas_id], references: [id])
+  total_users    Int
+  total_pixels   Int
+  last_placed_at DateTime @db.Timestamptz(6)
+
+  @@unique([frame_id])
+}
+
+// todo
+// view canvas_colors {canvas_id Int, color_id Int, count Int}
+// view frame_colors {frame_id String, color_id Int, count Int}
 
 view history_snapshot_windows {
   canvas_id     Int

--- a/packages/backend/src/routes/api/v1/statistics.ts
+++ b/packages/backend/src/routes/api/v1/statistics.ts
@@ -1,4 +1,5 @@
 import {
+  CanvasColorStatsParamModel,
   CanvasIdParamModel,
   EventIdParamModel,
   LeaderboardQueryModel,
@@ -8,9 +9,10 @@ import { Router } from "express";
 import { typedRouter } from "@/middleware/typedRouter";
 import { validate } from "@/middleware/validate";
 import {
+  getCanvasColorLeaderboard,
+  getCanvasLeaderboard,
   getCanvasStatisticsSummary,
   getEventStatisticsSummary,
-  getLeaderboard,
   getUserStats,
 } from "@/services/statisticsService";
 import { addSpanAttributes } from "@/utils/otel";
@@ -41,8 +43,34 @@ statisticsRouter.get(
       "query.size": req.query.size ?? false,
     });
 
-    const leaderboard = await getLeaderboard(
+    const leaderboard = await getCanvasLeaderboard(
       req.params.canvasId,
+      req.query.page,
+      req.query.size,
+    );
+    res.status(200).json(leaderboard);
+
+    addSpanAttributes(req, { "response.size": leaderboard.size });
+  },
+);
+
+statisticsRouter.get(
+  "/leaderboard/canvas/color/:canvasId/:colorId",
+  validate({
+    params: CanvasColorStatsParamModel,
+    query: LeaderboardQueryModel,
+  }),
+  async (req, res) => {
+    addSpanAttributes(req, {
+      "canvas.id": req.params.canvasId,
+      "color.id": req.params.colorId,
+      "query.page": req.query.page ?? false,
+      "query.size": req.query.size ?? false,
+    });
+
+    const leaderboard = await getCanvasColorLeaderboard(
+      req.params.canvasId,
+      req.params.colorId,
       req.query.page,
       req.query.size,
     );

--- a/packages/backend/src/routes/api/v1/statistics.ts
+++ b/packages/backend/src/routes/api/v1/statistics.ts
@@ -17,6 +17,7 @@ import {
   getEventStatisticsSummary,
   getFrameColorLeaderboard,
   getFrameLeaderboard,
+  getFrameStatisticsSummary,
   getUserStats,
 } from "@/services/statisticsService";
 import { addSpanAttributes } from "@/utils/otel";
@@ -149,6 +150,17 @@ statisticsRouter.get(
     addSpanAttributes(req, { "event.id": req.params.eventId });
 
     const summary = await getEventStatisticsSummary(req.params.eventId);
+    res.status(200).json(summary);
+  },
+);
+
+statisticsRouter.get(
+  "/summary/frame/:frameId",
+  validate({ params: FrameIdParamModel }),
+  async (req, res) => {
+    addSpanAttributes(req, { "frame.id": req.params.frameId });
+
+    const summary = await getFrameStatisticsSummary(req.params.frameId);
     res.status(200).json(summary);
   },
 );

--- a/packages/backend/src/routes/api/v1/statistics.ts
+++ b/packages/backend/src/routes/api/v1/statistics.ts
@@ -2,6 +2,7 @@ import {
   CanvasColorStatsParamModel,
   CanvasIdParamModel,
   EventIdParamModel,
+  FrameIdParamModel,
   LeaderboardQueryModel,
   UserCanvasParamModel,
 } from "@blurple-canvas-web/types";
@@ -13,6 +14,8 @@ import {
   getCanvasLeaderboard,
   getCanvasStatisticsSummary,
   getEventStatisticsSummary,
+  getFrameColorLeaderboard,
+  getFrameLeaderboard,
   getUserStats,
 } from "@/services/statisticsService";
 import { addSpanAttributes } from "@/utils/otel";
@@ -70,6 +73,55 @@ statisticsRouter.get(
 
     const leaderboard = await getCanvasColorLeaderboard(
       req.params.canvasId,
+      req.params.colorId,
+      req.query.page,
+      req.query.size,
+    );
+    res.status(200).json(leaderboard);
+
+    addSpanAttributes(req, { "response.size": leaderboard.size });
+  },
+);
+
+statisticsRouter.get(
+  "/leaderboard/frame/all/:frameId",
+  validate({ params: FrameIdParamModel, query: LeaderboardQueryModel }),
+  async (req, res) => {
+    addSpanAttributes(req, {
+      "frame.id": req.params.frameId,
+      "query.page": req.query.page ?? false,
+      "query.size": req.query.size ?? false,
+    });
+
+    const leaderboard = await getFrameLeaderboard(
+      req.params.frameId,
+      req.query.page,
+      req.query.size,
+    );
+    res.status(200).json(leaderboard);
+
+    addSpanAttributes(req, { "response.size": leaderboard.size });
+  },
+);
+
+statisticsRouter.get(
+  "/leaderboard/frame/color/:frameId/:colorId",
+  validate({
+    params: CanvasColorStatsParamModel.extend({
+      frameId: FrameIdParamModel.shape.frameId,
+    }),
+    query: LeaderboardQueryModel,
+  }),
+  async (req, res) => {
+    addSpanAttributes(req, {
+      "frame.id": req.params.frameId,
+      "color.id": req.params.colorId,
+      "query.page": req.query.page ?? false,
+      "query.size": req.query.size ?? false,
+    });
+
+    const leaderboard = await getFrameColorLeaderboard(
+      req.params.frameId,
       req.params.colorId,
       req.query.page,
       req.query.size,

--- a/packages/backend/src/routes/api/v1/statistics.ts
+++ b/packages/backend/src/routes/api/v1/statistics.ts
@@ -2,6 +2,7 @@ import {
   CanvasColorStatsParamModel,
   CanvasIdParamModel,
   EventIdParamModel,
+  FrameColorStatsParamModel,
   FrameIdParamModel,
   LeaderboardQueryModel,
   UserCanvasParamModel,
@@ -107,9 +108,7 @@ statisticsRouter.get(
 statisticsRouter.get(
   "/leaderboard/frame/:frameId/color/:colorId",
   validate({
-    params: CanvasColorStatsParamModel.extend({
-      frameId: FrameIdParamModel.shape.frameId,
-    }),
+    params: FrameColorStatsParamModel,
     query: LeaderboardQueryModel,
   }),
   async (req, res) => {

--- a/packages/backend/src/routes/api/v1/statistics.ts
+++ b/packages/backend/src/routes/api/v1/statistics.ts
@@ -48,11 +48,11 @@ statisticsRouter.get(
       "query.size": req.query.size ?? false,
     });
 
-    const leaderboard = await getCanvasLeaderboard(
-      req.params.canvasId,
-      req.query.page,
-      req.query.size,
-    );
+    const leaderboard = await getCanvasLeaderboard({
+      canvasId: req.params.canvasId,
+      page: req.query.page,
+      size: req.query.size,
+    });
     res.status(200).json(leaderboard);
 
     addSpanAttributes(req, { "response.size": leaderboard.size });
@@ -73,12 +73,12 @@ statisticsRouter.get(
       "query.size": req.query.size ?? false,
     });
 
-    const leaderboard = await getCanvasColorLeaderboard(
-      req.params.canvasId,
-      req.params.colorId,
-      req.query.page,
-      req.query.size,
-    );
+    const leaderboard = await getCanvasColorLeaderboard({
+      canvasId: req.params.canvasId,
+      colorId: req.params.colorId,
+      page: req.query.page,
+      size: req.query.size,
+    });
     res.status(200).json(leaderboard);
 
     addSpanAttributes(req, { "response.size": leaderboard.size });
@@ -95,11 +95,11 @@ statisticsRouter.get(
       "query.size": req.query.size ?? false,
     });
 
-    const leaderboard = await getFrameLeaderboard(
-      req.params.frameId,
-      req.query.page,
-      req.query.size,
-    );
+    const leaderboard = await getFrameLeaderboard({
+      frameId: req.params.frameId,
+      page: req.query.page,
+      size: req.query.size,
+    });
     res.status(200).json(leaderboard);
 
     addSpanAttributes(req, { "response.size": leaderboard.size });
@@ -120,12 +120,12 @@ statisticsRouter.get(
       "query.size": req.query.size ?? false,
     });
 
-    const leaderboard = await getFrameColorLeaderboard(
-      req.params.frameId,
-      req.params.colorId,
-      req.query.page,
-      req.query.size,
-    );
+    const leaderboard = await getFrameColorLeaderboard({
+      frameId: req.params.frameId,
+      colorId: req.params.colorId,
+      page: req.query.page,
+      size: req.query.size,
+    });
     res.status(200).json(leaderboard);
 
     addSpanAttributes(req, { "response.size": leaderboard.size });

--- a/packages/backend/src/routes/api/v1/statistics.ts
+++ b/packages/backend/src/routes/api/v1/statistics.ts
@@ -37,7 +37,7 @@ statisticsRouter.get(
 );
 
 statisticsRouter.get(
-  "/leaderboard/canvas/all/:canvasId",
+  "/leaderboard/canvas/:canvasId",
   validate({ params: CanvasIdParamModel, query: LeaderboardQueryModel }),
   async (req, res) => {
     addSpanAttributes(req, {
@@ -58,7 +58,7 @@ statisticsRouter.get(
 );
 
 statisticsRouter.get(
-  "/leaderboard/canvas/color/:canvasId/:colorId",
+  "/leaderboard/canvas/:canvasId/color/:colorId",
   validate({
     params: CanvasColorStatsParamModel,
     query: LeaderboardQueryModel,
@@ -84,7 +84,7 @@ statisticsRouter.get(
 );
 
 statisticsRouter.get(
-  "/leaderboard/frame/all/:frameId",
+  "/leaderboard/frame/:frameId",
   validate({ params: FrameIdParamModel, query: LeaderboardQueryModel }),
   async (req, res) => {
     addSpanAttributes(req, {
@@ -105,7 +105,7 @@ statisticsRouter.get(
 );
 
 statisticsRouter.get(
-  "/leaderboard/frame/color/:frameId/:colorId",
+  "/leaderboard/frame/:frameId/color/:colorId",
   validate({
     params: CanvasColorStatsParamModel.extend({
       frameId: FrameIdParamModel.shape.frameId,

--- a/packages/backend/src/routes/api/v1/statistics.ts
+++ b/packages/backend/src/routes/api/v1/statistics.ts
@@ -32,7 +32,7 @@ statisticsRouter.get(
 );
 
 statisticsRouter.get(
-  "/leaderboard/:canvasId",
+  "/leaderboard/canvas/all/:canvasId",
   validate({ params: CanvasIdParamModel, query: LeaderboardQueryModel }),
   async (req, res) => {
     addSpanAttributes(req, {

--- a/packages/backend/src/services/statisticsService.ts
+++ b/packages/backend/src/services/statisticsService.ts
@@ -3,6 +3,7 @@ import type {
   CanvasInfo,
   CanvasStatisticsSummary,
   EventStatisticsSummary,
+  Frame,
   LeaderboardEntrySchema,
   Paginated,
   PaletteColorSummary,
@@ -142,6 +143,109 @@ export async function getCanvasColorLeaderboard(
   const total = await prisma.color_leaderboard.count({
     where: {
       canvas_id: canvasId,
+      color_id: colorId,
+    },
+  });
+
+  return {
+    total,
+    page: Math.max(page, 1),
+    size: take,
+    entries: leaderboard.map((row) => ({
+      rank: row.rank,
+      userId: row.user_id.toString(),
+      totalPixels: row.total_pixels,
+      username: row.discord_user_profile?.username,
+      profilePictureUrl:
+        row.discord_user_profile?.profile_picture_url ??
+        createDefaultAvatarUrl(row.user_id),
+    })),
+  };
+}
+
+export async function getFrameLeaderboard(
+  frameId: Frame["id"],
+  page = 1,
+  size = 10,
+): Promise<Paginated<typeof LeaderboardEntrySchema>> {
+  const take = Math.min(Math.max(size, 1), 40); // Arbitrary maximum
+  const leaderboard = await prisma.leaderboard_frame.findMany({
+    skip: Math.max((page - 1) * take, 0),
+    take,
+    orderBy: {
+      rank: "asc",
+    },
+    where: {
+      frame_id: frameId,
+    },
+    select: {
+      rank: true,
+      user_id: true,
+      discord_user_profile: {
+        select: {
+          username: true,
+          profile_picture_url: true,
+        },
+      },
+      total_pixels: true,
+    },
+  });
+
+  const total = await prisma.leaderboard_frame.count({
+    where: {
+      frame_id: frameId,
+    },
+  });
+
+  return {
+    total,
+    page: Math.max(page, 1),
+    size: take,
+    entries: leaderboard.map((row) => ({
+      rank: row.rank,
+      userId: row.user_id.toString(),
+      totalPixels: row.total_pixels,
+      username: row.discord_user_profile?.username,
+      profilePictureUrl:
+        row.discord_user_profile?.profile_picture_url ??
+        createDefaultAvatarUrl(row.user_id),
+    })),
+  };
+}
+
+export async function getFrameColorLeaderboard(
+  frameId: Frame["id"],
+  colorId: PaletteColorSummary["id"],
+  page = 1,
+  size = 10,
+): Promise<Paginated<typeof LeaderboardEntrySchema>> {
+  const take = Math.min(Math.max(size, 1), 40); // Arbitrary maximum
+  const leaderboard = await prisma.color_leaderboard_frame.findMany({
+    skip: Math.max((page - 1) * take, 0),
+    take,
+    orderBy: {
+      rank: "asc",
+    },
+    where: {
+      frame_id: frameId,
+      color_id: colorId,
+    },
+    select: {
+      rank: true,
+      user_id: true,
+      discord_user_profile: {
+        select: {
+          username: true,
+          profile_picture_url: true,
+        },
+      },
+      total_pixels: true,
+    },
+  });
+
+  const total = await prisma.color_leaderboard_frame.count({
+    where: {
+      frame_id: frameId,
       color_id: colorId,
     },
   });

--- a/packages/backend/src/services/statisticsService.ts
+++ b/packages/backend/src/services/statisticsService.ts
@@ -5,6 +5,7 @@ import type {
   EventStatisticsSummary,
   LeaderboardEntrySchema,
   Paginated,
+  PaletteColorSummary,
   UserStats,
 } from "@blurple-canvas-web/types";
 import { prisma } from "@/client";
@@ -58,7 +59,7 @@ export async function getUserStats(
  * Retrieves the top `size` (max 40), from the rank `(page - 1) * size`
  * users on the leaderboard for a canvas.
  */
-export async function getLeaderboard(
+export async function getCanvasLeaderboard(
   canvasId: CanvasInfo["id"],
   page = 1,
   size = 10,
@@ -89,6 +90,59 @@ export async function getLeaderboard(
   const total = await prisma.leaderboard.count({
     where: {
       canvas_id: canvasId,
+    },
+  });
+
+  return {
+    total,
+    page: Math.max(page, 1),
+    size: take,
+    entries: leaderboard.map((row) => ({
+      rank: row.rank,
+      userId: row.user_id.toString(),
+      totalPixels: row.total_pixels,
+      username: row.discord_user_profile?.username,
+      profilePictureUrl:
+        row.discord_user_profile?.profile_picture_url ??
+        createDefaultAvatarUrl(row.user_id),
+    })),
+  };
+}
+
+export async function getCanvasColorLeaderboard(
+  canvasId: CanvasInfo["id"],
+  colorId: PaletteColorSummary["id"],
+  page = 1,
+  size = 10,
+): Promise<Paginated<typeof LeaderboardEntrySchema>> {
+  const take = Math.min(Math.max(size, 1), 40); // Arbitrary maximum
+  const leaderboard = await prisma.color_leaderboard.findMany({
+    skip: Math.max((page - 1) * take, 0),
+    take,
+    orderBy: {
+      rank: "asc",
+    },
+    where: {
+      canvas_id: canvasId,
+      color_id: colorId,
+    },
+    select: {
+      rank: true,
+      user_id: true,
+      discord_user_profile: {
+        select: {
+          username: true,
+          profile_picture_url: true,
+        },
+      },
+      total_pixels: true,
+    },
+  });
+
+  const total = await prisma.color_leaderboard.count({
+    where: {
+      canvas_id: canvasId,
+      color_id: colorId,
     },
   });
 

--- a/packages/backend/src/services/statisticsService.ts
+++ b/packages/backend/src/services/statisticsService.ts
@@ -57,15 +57,22 @@ export async function getUserStats(
   };
 }
 
+interface PaginatedParams {
+  page?: number;
+  size?: number;
+}
+
 /**
  * Retrieves the top `size` (max 40), from the rank `(page - 1) * size`
  * users on the leaderboard for a canvas.
  */
-export async function getCanvasLeaderboard(
-  canvasId: CanvasInfo["id"],
+export async function getCanvasLeaderboard({
+  canvasId,
   page = 1,
   size = 10,
-): Promise<Paginated<typeof LeaderboardEntrySchema>> {
+}: {
+  canvasId: CanvasInfo["id"];
+} & PaginatedParams): Promise<Paginated<typeof LeaderboardEntrySchema>> {
   const take = Math.min(Math.max(size, 1), 40); // Arbitrary maximum
   const leaderboard = await prisma.leaderboard.findMany({
     skip: Math.max((page - 1) * take, 0),
@@ -111,17 +118,21 @@ export async function getCanvasLeaderboard(
   };
 }
 
-export async function getCanvasColorLeaderboard(
-  canvasId: CanvasInfo["id"],
-  colorId: PaletteColorSummary["id"],
+export async function getCanvasColorLeaderboard({
+  canvasId,
+  colorId,
   page = 1,
   size = 10,
-): Promise<Paginated<typeof LeaderboardEntrySchema>> {
+}: {
+  canvasId: CanvasInfo["id"];
+  colorId?: PaletteColorSummary["id"];
+} & PaginatedParams): Promise<Paginated<typeof LeaderboardEntrySchema>> {
   const take = Math.min(Math.max(size, 1), 40); // Arbitrary maximum
   const leaderboard = await prisma.color_leaderboard.findMany({
     skip: Math.max((page - 1) * take, 0),
     take,
     orderBy: {
+      color_id: "asc",
       rank: "asc",
     },
     where: {
@@ -164,11 +175,13 @@ export async function getCanvasColorLeaderboard(
   };
 }
 
-export async function getFrameLeaderboard(
-  frameId: Frame["id"],
+export async function getFrameLeaderboard({
+  frameId,
   page = 1,
   size = 10,
-): Promise<Paginated<typeof LeaderboardEntrySchema>> {
+}: {
+  frameId: Frame["id"];
+} & PaginatedParams): Promise<Paginated<typeof LeaderboardEntrySchema>> {
   const take = Math.min(Math.max(size, 1), 40); // Arbitrary maximum
   const leaderboard = await prisma.leaderboard_frame.findMany({
     skip: Math.max((page - 1) * take, 0),
@@ -214,17 +227,21 @@ export async function getFrameLeaderboard(
   };
 }
 
-export async function getFrameColorLeaderboard(
-  frameId: Frame["id"],
-  colorId: PaletteColorSummary["id"],
+export async function getFrameColorLeaderboard({
+  frameId,
+  colorId,
   page = 1,
   size = 10,
-): Promise<Paginated<typeof LeaderboardEntrySchema>> {
+}: {
+  frameId: Frame["id"];
+  colorId?: PaletteColorSummary["id"];
+} & PaginatedParams): Promise<Paginated<typeof LeaderboardEntrySchema>> {
   const take = Math.min(Math.max(size, 1), 40); // Arbitrary maximum
   const leaderboard = await prisma.color_leaderboard_frame.findMany({
     skip: Math.max((page - 1) * take, 0),
     take,
     orderBy: {
+      color_id: "asc",
       rank: "asc",
     },
     where: {

--- a/packages/backend/src/services/statisticsService.ts
+++ b/packages/backend/src/services/statisticsService.ts
@@ -4,6 +4,7 @@ import type {
   CanvasStatisticsSummary,
   EventStatisticsSummary,
   Frame,
+  FrameStatisticsSummary,
   LeaderboardEntrySchema,
   Paginated,
   PaletteColorSummary,
@@ -302,5 +303,24 @@ export async function getEventStatisticsSummary(
     eventId,
     totalUsersInvolved: stats.total_users ?? 0,
     totalPixelsPlaced: stats.total_pixels ?? 0,
+  };
+}
+
+export async function getFrameStatisticsSummary(
+  frameId: Frame["id"],
+): Promise<FrameStatisticsSummary> {
+  const stats = await prisma.frame_stats.findUnique({
+    where: { frame_id: frameId },
+  });
+
+  if (!stats) {
+    throw new NotFoundError(`Frame statistics not found for frame ${frameId}`);
+  }
+
+  return {
+    frameId,
+    totalUsersInvolved: stats.total_users ?? 0,
+    totalPixelsPlaced: stats.total_pixels ?? 0,
+    lastPlacedAt: stats.last_placed_at.toISOString() ?? null,
   };
 }

--- a/packages/backend/src/services/statisticsService.ts
+++ b/packages/backend/src/services/statisticsService.ts
@@ -274,7 +274,18 @@ export async function getCanvasStatisticsSummary(
     where: { canvas_id: canvasId },
   });
 
-  if (!stats) {
+  const colorDistribution = await prisma.canvas_colors.findMany({
+    where: { canvas_id: canvasId },
+    select: {
+      color_id: true,
+      count: true,
+    },
+    orderBy: {
+      count: "desc",
+    },
+  });
+
+  if (!stats || !colorDistribution) {
     throw new NotFoundError(
       `Canvas statistics not found for canvas ${canvasId}`,
     );
@@ -285,6 +296,10 @@ export async function getCanvasStatisticsSummary(
     totalUsersInvolved: stats.total_users ?? 0,
     totalPixelsPlaced: stats.total_pixels ?? 0,
     lastPlacedAt: stats.last_placed_at.toISOString() ?? null,
+    colorDistribution: colorDistribution.map((entry) => ({
+      colorId: entry.color_id,
+      count: entry.count,
+    })),
   };
 }
 
@@ -313,6 +328,17 @@ export async function getFrameStatisticsSummary(
     where: { frame_id: frameId },
   });
 
+  const colorDistribution = await prisma.frame_colors.findMany({
+    where: { frame_id: frameId },
+    select: {
+      color_id: true,
+      count: true,
+    },
+    orderBy: {
+      count: "desc",
+    },
+  });
+
   if (!stats) {
     throw new NotFoundError(`Frame statistics not found for frame ${frameId}`);
   }
@@ -322,5 +348,9 @@ export async function getFrameStatisticsSummary(
     totalUsersInvolved: stats.total_users ?? 0,
     totalPixelsPlaced: stats.total_pixels ?? 0,
     lastPlacedAt: stats.last_placed_at.toISOString() ?? null,
+    colorDistribution: colorDistribution.map((entry) => ({
+      colorId: entry.color_id,
+      count: entry.count,
+    })),
   };
 }

--- a/packages/backend/src/services/statisticsService.ts
+++ b/packages/backend/src/services/statisticsService.ts
@@ -291,6 +291,12 @@ export async function getCanvasStatisticsSummary(
     where: { canvas_id: canvasId },
   });
 
+  if (!stats) {
+    throw new NotFoundError(
+      `Canvas statistics not found for canvas ${canvasId}`,
+    );
+  }
+
   const colorDistribution = await prisma.canvas_colors.findMany({
     where: { canvas_id: canvasId },
     select: {
@@ -301,12 +307,6 @@ export async function getCanvasStatisticsSummary(
       count: "desc",
     },
   });
-
-  if (!stats || !colorDistribution) {
-    throw new NotFoundError(
-      `Canvas statistics not found for canvas ${canvasId}`,
-    );
-  }
 
   return {
     canvasId,
@@ -345,6 +345,10 @@ export async function getFrameStatisticsSummary(
     where: { frame_id: frameId },
   });
 
+  if (!stats) {
+    throw new NotFoundError(`Frame statistics not found for frame ${frameId}`);
+  }
+
   const colorDistribution = await prisma.frame_colors.findMany({
     where: { frame_id: frameId },
     select: {
@@ -355,10 +359,6 @@ export async function getFrameStatisticsSummary(
       count: "desc",
     },
   });
-
-  if (!stats) {
-    throw new NotFoundError(`Frame statistics not found for frame ${frameId}`);
-  }
 
   return {
     frameId,

--- a/packages/frontend/src/app/canvas/[canvasId]/leaderboard/Leaderboard.tsx
+++ b/packages/frontend/src/app/canvas/[canvasId]/leaderboard/Leaderboard.tsx
@@ -4,7 +4,7 @@ import { styled } from "@mui/material";
 import { useId, useState } from "react";
 import Pagination from "@/components/Pagination";
 import { useCanvasContext } from "@/contexts";
-import { useLeaderboard } from "@/hooks/queries/useLeaderboard";
+import { useCanvasLeaderboard } from "@/hooks/queries/useLeaderboard";
 import LeaderboardRow, { LeaderboardRowSkeleton } from "./LeaderboardRow";
 
 const Wrapper = styled("div")`
@@ -43,7 +43,7 @@ export default function Leaderboard() {
   const {
     data: { total, page: currentPage, size = 10, entries } = {},
     isFetching: isLeaderboardFetching,
-  } = useLeaderboard(canvas.id, page);
+  } = useCanvasLeaderboard(canvas.id, { page });
   const isLeaderboardEmpty = entries?.length === 0;
 
   const [prevCanvasId, setPrevCanvasId] = useState(canvas.id);

--- a/packages/frontend/src/hooks/queries/index.ts
+++ b/packages/frontend/src/hooks/queries/index.ts
@@ -5,7 +5,7 @@ export { useCanvasList } from "./useCanvasList";
 export { useCanvasStats } from "./useCanvasStats";
 export { useEventInfo } from "./useEventInfo";
 export { useEventStats } from "./useEventStats";
-export { useCanvasLeaderboard as useLeaderboard } from "./useLeaderboard";
+export { useCanvasLeaderboard } from "./useLeaderboard";
 export { usePalette } from "./usePalette";
 export { useComplexPixelHistory, usePixelHistory } from "./usePixelHistory";
 export { useRefreshGuildMemberships, useUserData } from "./useUserData";

--- a/packages/frontend/src/hooks/queries/index.ts
+++ b/packages/frontend/src/hooks/queries/index.ts
@@ -5,7 +5,7 @@ export { useCanvasList } from "./useCanvasList";
 export { useCanvasStats } from "./useCanvasStats";
 export { useEventInfo } from "./useEventInfo";
 export { useEventStats } from "./useEventStats";
-export { useLeaderboard } from "./useLeaderboard";
+export { useCanvasLeaderboard as useLeaderboard } from "./useLeaderboard";
 export { usePalette } from "./usePalette";
 export { useComplexPixelHistory, usePixelHistory } from "./usePixelHistory";
 export { useRefreshGuildMemberships, useUserData } from "./useUserData";

--- a/packages/frontend/src/hooks/queries/useFrameStats.tsx
+++ b/packages/frontend/src/hooks/queries/useFrameStats.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { Frame, FrameStatisticsSummary } from "@blurple-canvas-web/types";
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import config from "@/config/clientConfig";
+
+export function useFrameStats(
+  frameId?: Frame["id"],
+  useQueryOptions?: Omit<
+    UseQueryOptions<FrameStatisticsSummary | null>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  const getFrameStats = async () => {
+    if (!frameId) return null;
+
+    const response = await axios.get<FrameStatisticsSummary>(
+      `${config.apiUrl}/api/v1/statistics/summary/frame/${encodeURIComponent(frameId)}`,
+    );
+    return response.data;
+  };
+
+  return useQuery<FrameStatisticsSummary | null>({
+    queryKey: ["statistics/summary/frame", frameId],
+    queryFn: getFrameStats,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    enabled: Boolean(frameId),
+    ...useQueryOptions,
+  });
+}

--- a/packages/frontend/src/hooks/queries/useLeaderboard.tsx
+++ b/packages/frontend/src/hooks/queries/useLeaderboard.tsx
@@ -1,25 +1,39 @@
 "use client";
 
-import type { CanvasInfo, LeaderboardRequest } from "@blurple-canvas-web/types";
+import type {
+  CanvasInfo,
+  LeaderboardRequest,
+  PaletteColorSummary,
+} from "@blurple-canvas-web/types";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import config from "@/config/clientConfig";
 
-export function useLeaderboard(
+interface UseLeaderboardParams {
+  page?: number;
+  size?: number;
+  colorId?: PaletteColorSummary["id"];
+}
+
+export function useCanvasLeaderboard(
   canvasId: CanvasInfo["id"],
-  page = 1,
-  size = 10,
+  { page = 1, size = 10, colorId }: UseLeaderboardParams,
 ) {
   const getLeaderboard = async (): Promise<LeaderboardRequest.ResBody> => {
-    const response = await axios.get<LeaderboardRequest.ResBody>(
-      `${config.apiUrl}/api/v1/statistics/leaderboard/canvas/${encodeURIComponent(canvasId)}`,
-      { params: { page, size } },
-    );
+    const baseUrl = `${config.apiUrl}/api/v1/statistics/leaderboard/canvas/${encodeURIComponent(
+      canvasId,
+    )}`;
+    const url =
+      colorId ? `${baseUrl}/color/${encodeURIComponent(colorId)}` : baseUrl;
+
+    const response = await axios.get<LeaderboardRequest.ResBody>(url, {
+      params: { page, size },
+    });
     return response.data;
   };
 
   return useQuery<LeaderboardRequest.ResBody>({
-    queryKey: ["leaderboard", canvasId, { page, size }],
+    queryKey: ["leaderboard", canvasId, { page, size, colorId }],
     queryFn: getLeaderboard,
     placeholderData: keepPreviousData,
     refetchOnMount: false,

--- a/packages/frontend/src/hooks/queries/useLeaderboard.tsx
+++ b/packages/frontend/src/hooks/queries/useLeaderboard.tsx
@@ -12,7 +12,7 @@ export function useLeaderboard(
 ) {
   const getLeaderboard = async (): Promise<LeaderboardRequest.ResBody> => {
     const response = await axios.get<LeaderboardRequest.ResBody>(
-      `${config.apiUrl}/api/v1/statistics/leaderboard/canvas/all/${encodeURIComponent(canvasId)}`,
+      `${config.apiUrl}/api/v1/statistics/leaderboard/canvas/${encodeURIComponent(canvasId)}`,
       { params: { page, size } },
     );
     return response.data;

--- a/packages/frontend/src/hooks/queries/useLeaderboard.tsx
+++ b/packages/frontend/src/hooks/queries/useLeaderboard.tsx
@@ -2,6 +2,7 @@
 
 import type {
   CanvasInfo,
+  Frame,
   LeaderboardRequest,
   PaletteColorSummary,
 } from "@blurple-canvas-web/types";
@@ -43,7 +44,7 @@ export function useCanvasLeaderboard(
 }
 
 export function useFrameLeaderboard(
-  frameId: number,
+  frameId: Frame["id"],
   { page = 1, size = 10, colorId }: UseLeaderboardParams,
 ) {
   const getLeaderboard = async (): Promise<LeaderboardRequest.ResBody> => {

--- a/packages/frontend/src/hooks/queries/useLeaderboard.tsx
+++ b/packages/frontend/src/hooks/queries/useLeaderboard.tsx
@@ -12,7 +12,7 @@ export function useLeaderboard(
 ) {
   const getLeaderboard = async (): Promise<LeaderboardRequest.ResBody> => {
     const response = await axios.get<LeaderboardRequest.ResBody>(
-      `${config.apiUrl}/api/v1/statistics/leaderboard/${encodeURIComponent(canvasId)}`,
+      `${config.apiUrl}/api/v1/statistics/leaderboard/canvas/all/${encodeURIComponent(canvasId)}`,
       { params: { page, size } },
     );
     return response.data;

--- a/packages/frontend/src/hooks/queries/useLeaderboard.tsx
+++ b/packages/frontend/src/hooks/queries/useLeaderboard.tsx
@@ -41,3 +41,30 @@ export function useCanvasLeaderboard(
     staleTime: 30_000, // 30 seconds
   });
 }
+
+export function useFrameLeaderboard(
+  frameId: number,
+  { page = 1, size = 10, colorId }: UseLeaderboardParams,
+) {
+  const getLeaderboard = async (): Promise<LeaderboardRequest.ResBody> => {
+    const baseUrl = `${config.apiUrl}/api/v1/statistics/leaderboard/frame/${encodeURIComponent(
+      frameId,
+    )}`;
+    const url =
+      colorId ? `${baseUrl}/color/${encodeURIComponent(colorId)}` : baseUrl;
+
+    const response = await axios.get<LeaderboardRequest.ResBody>(url, {
+      params: { page, size },
+    });
+    return response.data;
+  };
+
+  return useQuery<LeaderboardRequest.ResBody>({
+    queryKey: ["leaderboard", "frame", frameId, { page, size, colorId }],
+    queryFn: getLeaderboard,
+    placeholderData: keepPreviousData,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    staleTime: 30_000, // 30 seconds
+  });
+}

--- a/packages/types/src/models/canvas.models.ts
+++ b/packages/types/src/models/canvas.models.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { CanvasPlaceState } from "../canvasInfo.js";
+import { ColorIdParamModel } from "./color.models.js";
 import { DiscordSnowflakeSchema } from "./snowflake.js";
 
 export const CanvasIdParamModel = z.object({
@@ -47,4 +48,9 @@ export const CanvasExportParamModel = z.object({
 
 export const CanvasTimelapseParamModel = z.object({
   raw: z.stringbool().optional(),
+});
+
+export const CanvasColorStatsParamModel = z.object({
+  canvasId: CanvasIdParamModel.shape.canvasId,
+  colorId: ColorIdParamModel.shape.colorId,
 });

--- a/packages/types/src/models/frame.models.ts
+++ b/packages/types/src/models/frame.models.ts
@@ -4,6 +4,7 @@ import {
   CanvasExportScaleSchema,
   CanvasIdParamModel,
 } from "./canvas.models.js";
+import { ColorIdParamModel } from "./index.js";
 import { DiscordSnowflakeSchema } from "./snowflake.js";
 
 export const FrameIdParamModel = z.object({
@@ -109,4 +110,9 @@ export const FrameGuildIdsQueryModel = z.object({
 export const ExportFrameParamModel = z.object({
   frameId: FrameIdParamModel.shape.frameId,
   scale: CanvasExportScaleSchema,
+});
+
+export const FrameColorStatsParamModel = z.object({
+  frameId: FrameIdParamModel.shape.frameId,
+  colorId: ColorIdParamModel.shape.colorId,
 });

--- a/packages/types/src/statistics.ts
+++ b/packages/types/src/statistics.ts
@@ -23,11 +23,19 @@ export const LeaderboardEntrySchema = z.object({
 
 export type LeaderboardEntry = z.infer<typeof LeaderboardEntrySchema>;
 
+const ColorDistributionList = z.array(
+  z.object({
+    colorId: z.number().int().positive(),
+    count: z.number().int().nonnegative(),
+  }),
+);
+
 export const CanvasStatisticsSummarySchema = z.object({
   canvasId: z.number().int().positive(),
   totalUsersInvolved: z.number().int().nonnegative(),
   totalPixelsPlaced: z.number().int().nonnegative(),
   lastPlacedAt: z.iso.datetime().nullable(),
+  colorDistribution: ColorDistributionList,
 });
 
 export type CanvasStatisticsSummary = z.infer<
@@ -49,6 +57,7 @@ export const FrameStatisticsSummarySchema = z.object({
   totalUsersInvolved: z.number().int().nonnegative(),
   totalPixelsPlaced: z.number().int().nonnegative(),
   lastPlacedAt: z.iso.datetime().nullable(),
+  colorDistribution: ColorDistributionList,
 });
 
 export type FrameStatisticsSummary = z.infer<

--- a/packages/types/src/statistics.ts
+++ b/packages/types/src/statistics.ts
@@ -43,3 +43,14 @@ export const EventStatisticsSummarySchema = z.object({
 export type EventStatisticsSummary = z.infer<
   typeof EventStatisticsSummarySchema
 >;
+
+export const FrameStatisticsSummarySchema = z.object({
+  frameId: z.string().regex(/^[0-9a-fA-F]{6}$/),
+  totalUsersInvolved: z.number().int().nonnegative(),
+  totalPixelsPlaced: z.number().int().nonnegative(),
+  lastPlacedAt: z.iso.datetime().nullable(),
+});
+
+export type FrameStatisticsSummary = z.infer<
+  typeof FrameStatisticsSummarySchema
+>;


### PR DESCRIPTION
## New views
- `frame_stats` - total users, total pixels, last placed at
- `canvas_colors`, `frame_colors` - color, count
- `color_leaderboard`, `color_leaderboard_frame` - color, user, rank
## New/updated endpoints
- `/statistics/leaderboard/:canvasId` -> `/statistics/leaderboard/canvas/:canvasId`
- \+ `/statistics/leaderboard/frame/:frameId`, same params as the existing leaderboard endpoint (ditto to below)
- \+ `/statistics/leaderboard/canvas/:canvasId/color/:colorId`
- \+ `/statistics/leaderboard/frame/:frameId/color/:colorId`
- \~ `/summary/canvas/:canvasId` now includes `colorDistribution { color, count }[]`
- \+ `/summary/frame/:frameId`, same response format as the canvas summary